### PR TITLE
Ignore query params

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ app.use(apiMetrics())
 - useUniqueHistogramName - Add to metrics names the project name as a prefix (from package.json)
 - metricsPrefix - A custom matrics names prefix, the package will add underscode between your prefix to the metric name.
 - excludeRoutes - Array of routes to exclude. Routes should be in your framework syntax.
+- includeQueryParams - A boolean that indicate if to include query params in route, the query parmas will be sorted in order to eliminate the number of unique labels.
 
 ### Access the metrics
 

--- a/src/metrics-middleware.js
+++ b/src/metrics-middleware.js
@@ -5,7 +5,6 @@ require('pkginfo')(module, ['name']);
 const debug = require('debug')(module.exports.name);
 const utils = require('./utils');
 const setupOptions = {};
-const routers = {};
 
 module.exports = (appVersion, projectName) => {
     return (options = {}) => {

--- a/src/metrics-middleware.js
+++ b/src/metrics-middleware.js
@@ -111,7 +111,7 @@ function _getRoute(req) {
         }
 
         if (route === '') {
-            route = req.originalUrl;
+            route = req.originalUrl.split('?')[0];
         } else {
             const splittedRoute = route.split('/');
             const splittedUrl = req.originalUrl.split('/');

--- a/src/metrics-middleware.js
+++ b/src/metrics-middleware.js
@@ -8,11 +8,11 @@ const setupOptions = {};
 
 module.exports = (appVersion, projectName) => {
     return (options = {}) => {
-        const { metricsPath, defaultMetricsInterval = 10000, durationBuckets, requestSizeBuckets, responseSizeBuckets, useUniqueHistogramName, metricsPrefix, excludeRoutes, includeQuery } = options;
+        const { metricsPath, defaultMetricsInterval = 10000, durationBuckets, requestSizeBuckets, responseSizeBuckets, useUniqueHistogramName, metricsPrefix, excludeRoutes, includeQueryParams } = options;
         debug(`Init metrics middleware with options: ${JSON.stringify(options)}`);
         setupOptions.metricsRoute = metricsPath || '/metrics';
         setupOptions.excludeRoutes = excludeRoutes || [];
-        setupOptions.includeQuery = includeQuery;
+        setupOptions.includeQueryParams = includeQueryParams;
 
         let metricNames = {
             http_request_duration_seconds: 'http_request_duration_seconds',
@@ -121,7 +121,7 @@ function _getRoute(req) {
             route = baseUrl + route;
         }
 
-        if (setupOptions.includeQuery === true && req.query && Object.keys(req.query).length > 0) {
+        if (setupOptions.includeQueryParams === true && req.query && Object.keys(req.query).length > 0) {
             route = `${route}?${Object.keys(req.query).sort().map((queryParam) => `${queryParam}=<?>`).join('&')}`;
         }
     }

--- a/src/metrics-middleware.js
+++ b/src/metrics-middleware.js
@@ -121,7 +121,7 @@ function _getRoute(req) {
             route = baseUrl + route;
         }
 
-        if (setupOptions.includeQueryParams === true && req.query && Object.keys(req.query).length > 0) {
+        if (setupOptions.includeQueryParams === true && Object.keys(req.query).length > 0) {
             route = `${route}?${Object.keys(req.query).sort().map((queryParam) => `${queryParam}=<?>`).join('&')}`;
         }
     }

--- a/src/metrics-middleware.js
+++ b/src/metrics-middleware.js
@@ -8,10 +8,11 @@ const setupOptions = {};
 
 module.exports = (appVersion, projectName) => {
     return (options = {}) => {
-        const { metricsPath, defaultMetricsInterval = 10000, durationBuckets, requestSizeBuckets, responseSizeBuckets, useUniqueHistogramName, metricsPrefix, excludeRoutes } = options;
+        const { metricsPath, defaultMetricsInterval = 10000, durationBuckets, requestSizeBuckets, responseSizeBuckets, useUniqueHistogramName, metricsPrefix, excludeRoutes, includeQuery } = options;
         debug(`Init metrics middleware with options: ${JSON.stringify(options)}`);
         setupOptions.metricsRoute = metricsPath || '/metrics';
         setupOptions.excludeRoutes = excludeRoutes || [];
+        setupOptions.includeQuery = includeQuery;
 
         let metricNames = {
             http_request_duration_seconds: 'http_request_duration_seconds',
@@ -118,6 +119,10 @@ function _getRoute(req) {
 
             const baseUrl = splittedUrl.slice(0, routeIndex).join('/');
             route = baseUrl + route;
+        }
+
+        if (setupOptions.includeQuery === true && req.query && Object.keys(req.query).length > 0) {
+            route = `${route}?${Object.keys(req.query).sort().map((queryParam) => `${queryParam}=<?>`).join('&')}`;
         }
     }
 

--- a/test/integration-tests/express/middleware-test.js
+++ b/test/integration-tests/express/middleware-test.js
@@ -124,6 +124,22 @@ describe('when using express framework', () => {
                     });
             });
         });
+        describe('when calling a GET endpoint with query parmas', () => {
+            before(() => {
+                return supertest(app)
+                    .get('/hello?test=test')
+                    .expect(200)
+                    .then((res) => {});
+            });
+            it('should add it to the histogram', () => {
+                return supertest(app)
+                    .get('/metrics')
+                    .expect(200)
+                    .then((res) => {
+                        expect(res.text).to.contain('http_request_duration_seconds_bucket{le="+Inf",method="GET",route="/hello",code="200"} 2');
+                    });
+            });
+        });
         describe('sub app', function () {
             describe('when calling a GET endpoint with path params', () => {
                 before(() => {
@@ -274,6 +290,22 @@ describe('when using express framework', () => {
                         });
                 });
             });
+            describe('when calling a GET endpoint with query parmas', () => {
+                before(() => {
+                    return supertest(app)
+                        .get('/v2?test=test')
+                        .expect(500)
+                        .then((res) => {});
+                });
+                it('should add it to the histogram', () => {
+                    return supertest(app)
+                        .get('/metrics')
+                        .expect(200)
+                        .then((res) => {
+                            expect(res.text).to.contain('http_request_duration_seconds_bucket{le="+Inf",method="GET",route="/v2",code="500"} 2');
+                        });
+                });
+            });
         });
         describe('sub-sub app with error handler in the sub app', function () {
             describe('when calling a GET endpoint with path params and sub router', () => {
@@ -409,6 +441,22 @@ describe('when using express framework', () => {
                         });
                 });
             });
+            describe('when calling a GET endpoint with query parmas', () => {
+                before(() => {
+                    return supertest(app)
+                        .get('/v2/v3?test=test')
+                        .expect(500)
+                        .then((res) => {});
+                });
+                it('should add it to the histogram', () => {
+                    return supertest(app)
+                        .get('/metrics')
+                        .expect(200)
+                        .then((res) => {
+                            expect(res.text).to.contain('http_request_duration_seconds_bucket{le="+Inf",method="GET",route="/v2/v3",code="500"} 2');
+                        });
+                });
+            });
         });
         describe('sub-sub app with error handler in the sub-sub app', function () {
             describe('when calling a GET endpoint with path params and sub router', () => {
@@ -541,6 +589,22 @@ describe('when using express framework', () => {
                         .expect(200)
                         .then((res) => {
                             expect(res.text).to.contain('method="GET",route="/v2/v4",code="500"');
+                        });
+                });
+            });
+            describe('when calling a GET endpoint with query parmas', () => {
+                before(() => {
+                    return supertest(app)
+                        .get('/v2/v4?test=test')
+                        .expect(500)
+                        .then((res) => {});
+                });
+                it('should add it to the histogram', () => {
+                    return supertest(app)
+                        .get('/metrics')
+                        .expect(200)
+                        .then((res) => {
+                            expect(res.text).to.contain('http_request_duration_seconds_bucket{le="+Inf",method="GET",route="/v2/v4",code="500"} 2');
                         });
                 });
             });

--- a/test/integration-tests/express/middleware-test.js
+++ b/test/integration-tests/express/middleware-test.js
@@ -796,4 +796,93 @@ describe('when using express framework', () => {
             });
         });
     });
+    describe('when start up with include query params', () => {
+        let app;
+        before(() => {
+            config.useUniqueHistogramName = true;
+            delete require.cache[require.resolve('./server/express-server')];
+            delete require.cache[require.resolve('../../../src/metrics-middleware.js')];
+            app = require('./server/express-server-exclude-routes');
+        });
+        describe('when calling a GET endpoint with one query param', () => {
+            before(() => {
+                return supertest(app)
+                    .get('/hello?test=test')
+                    .expect(200)
+                    .then((res) => {});
+            });
+            it('should add it to the histogram', () => {
+                return supertest(app)
+                    .get('/metrics')
+                    .expect(200)
+                    .then((res) => {
+                        expect(res.text).to.contain('method="GET",route="/hello?test=<?>",code="200"');
+                    });
+            });
+        });
+        describe('when calling a GET endpoint with two query params', () => {
+            before(() => {
+                return supertest(app)
+                    .get('/hello?test1=test&test2=test2')
+                    .expect(200)
+                    .then((res) => {});
+            });
+            it('should add it to the histogram and sort the query params', () => {
+                return supertest(app)
+                    .get('/metrics')
+                    .expect(200)
+                    .then((res) => {
+                        expect(res.text).to.contain('http_request_duration_seconds_count{method="GET",route="/hello?test1=<?>&test2=<?>",code="200"} 1');
+                    });
+            });
+        });
+        describe('when calling a GET endpoint with two query params in different order', () => {
+            before(() => {
+                return supertest(app)
+                    .get('/hello?test2=test&test1=test2')
+                    .expect(200)
+                    .then((res) => {});
+            });
+            it('should add it to the histogram and sort the query params', () => {
+                return supertest(app)
+                    .get('/metrics')
+                    .expect(200)
+                    .then((res) => {
+                        expect(res.text).to.contain('http_request_duration_seconds_count{method="GET",route="/hello?test1=<?>&test2=<?>",code="200"} 2');
+                    });
+            });
+        });
+        describe('when calling a GET endpoint with query param', () => {
+            before(() => {
+                return supertest(app)
+                    .get('/health/1234?test=test')
+                    .expect(200)
+                    .then((res) => {});
+            });
+            it('should add it to the histogram', () => {
+                return supertest(app)
+                    .get('/metrics')
+                    .expect(200)
+                    .then((res) => {
+                        expect(res.text).to.not.contain('method="GET",route="/health/:id?test=<?>",code="200"');
+                    });
+            });
+        });
+        describe('when calling a GET root endpoint with query param ', () => {
+            before(() => {
+                return supertest(app)
+                    .get('/?test=test')
+                    .expect(200)
+                    .then((res) => {});
+            });
+            it('should add it to the histogram', () => {
+                return supertest(app)
+                    .get('/metrics')
+                    .expect(200)
+                    .then((res) => {
+                        expect(res.text).to.contain('http_request_size_bytes_count{method="GET",route="/?test=<?>",code="200"} 1');
+                    });
+            });
+        });
+    });
 });

--- a/test/integration-tests/express/server/express-server-exclude-routes.js
+++ b/test/integration-tests/express/server/express-server-exclude-routes.js
@@ -5,8 +5,15 @@ const bodyParser = require('body-parser');
 const app = express();
 const middleware = require('../../../../src/index.js');
 
-app.use(middleware({ excludeRoutes: ['/health', '/health/:id'] }));
+app.use(middleware({ excludeRoutes: ['/health', '/health/:id'], includeQuery: true }));
 app.use(bodyParser.json());
+
+app.get('', (req, res, next) => {
+    setTimeout(() => {
+        res.json({ message: 'Hello World!' });
+        next();
+    }, Math.round(Math.random() * 200));
+});
 
 app.get('/hello', (req, res, next) => {
     setTimeout(() => {

--- a/test/integration-tests/express/server/express-server-exclude-routes.js
+++ b/test/integration-tests/express/server/express-server-exclude-routes.js
@@ -5,7 +5,7 @@ const bodyParser = require('body-parser');
 const app = express();
 const middleware = require('../../../../src/index.js');
 
-app.use(middleware({ excludeRoutes: ['/health', '/health/:id'], includeQuery: true }));
+app.use(middleware({ excludeRoutes: ['/health', '/health/:id'], includeQueryParams: true }));
 app.use(bodyParser.json());
 
 app.get('', (req, res, next) => {

--- a/test/integration-tests/nest-js/middleware-test.spec.ts
+++ b/test/integration-tests/nest-js/middleware-test.spec.ts
@@ -62,4 +62,101 @@ describe('when using nest-js framework', () => {
                 });
         });
     });
+    describe('When calling a GET user/:user_id/app-id/:app_id with user_id and app_id as pattern and query params', () => {
+        before(() => {
+            return request(server)
+                .get('/users/123/app-id/456?test=test')
+                .expect(200)
+                .expect({
+                    app_id: 'some_app_id'
+                });
+        });
+
+        it('should add it to the histogram', () => {
+            return request(server)
+                .get('/metrics')
+                .expect(200)
+                .then((res) => {
+                    expect(res.text).to.contain('http_response_size_bytes_count{method="GET",route="/users/:user_id/app-id/:app_id",code="200"} 2');
+                });
+        });
+    });
+});
+
+describe('when using nest-js framework and includeQueryParams', () => {
+    before(() => {
+        const middleware = require('../../../src/index.js');
+        server = express();
+
+        let module = Test.createTestingModule({imports: [UsersModule]});
+
+        return module.compile()
+            .then((compiledModule) => {
+                let app = compiledModule.createNestApplication(server);
+
+                app.use(middleware({ includeQueryParams: true }));
+
+                return app.init();
+            });
+    });
+    after(() => {
+        Prometheus.register.clear();
+    });
+    describe('When calling a GET user/:user_id/app-id/:app_id with user_id and app_id as pattern and query params', () => {
+        before(() => {
+            return request(server)
+                .get('/users/123/app-id/456?test=test')
+                .expect(200)
+                .expect({
+                    app_id: 'some_app_id'
+                });
+        });
+
+        it('should add it to the histogram', () => {
+            return request(server)
+                .get('/metrics')
+                .expect(200)
+                .then((res) => {
+                    expect(res.text).to.contain('http_response_size_bytes_count{method="GET",route="/users/:user_id/app-id/:app_id?test=<?>",code="200"} 1');
+                });
+        });
+    });
+    describe('When calling a GET user/:user_id/app-id/:app_id with user_id and app_id as pattern and two query params', () => {
+        before(() => {
+            return request(server)
+                .get('/users/123/app-id/456?test=test&test1=test1')
+                .expect(200)
+                .expect({
+                    app_id: 'some_app_id'
+                });
+        });
+
+        it('should add it to the histogram', () => {
+            return request(server)
+                .get('/metrics')
+                .expect(200)
+                .then((res) => {
+                    expect(res.text).to.contain('http_response_size_bytes_count{method="GET",route="/users/:user_id/app-id/:app_id?test=<?>&test1=<?>",code="200"} 1');
+                });
+        });
+    });
+    describe('When calling a GET user/:user_id/app-id/:app_id with user_id and app_id as pattern and two query params in different order', () => {
+        before(() => {
+            return request(server)
+                .get('/users/123/app-id/456?test1=test1&test=test')
+                .expect(200)
+                .expect({
+                    app_id: 'some_app_id'
+                });
+        });
+
+        it('should add it to the histogram', () => {
+            return request(server)
+                .get('/metrics')
+                .expect(200)
+                .then((res) => {
+                    expect(res.text).to.contain('http_response_size_bytes_count{method="GET",route="/users/:user_id/app-id/:app_id?test=<?>&test1=<?>",code="200"} 2');
+                });
+        });
+    });
 });


### PR DESCRIPTION
- Ignore query params in the cause of query params directly on the root route
- Add ability to add the query params to the route (without values)