### PR TITLE
Express: Use req.originalUrl if available instead of req.url

### DIFF
--- a/src/express-middleware.js
+++ b/src/express-middleware.js
@@ -90,12 +90,15 @@ class ExpressMiddleware {
             this.setupOptions.server = req.socket.server;
             this._collectDefaultServerMetrics(this.setupOptions.defaultMetricsInterval);
         }
-        if (req.url === this.setupOptions.metricsRoute) {
+
+        const routeUrl = req.originalUrl || req.url;
+
+        if (routeUrl === this.setupOptions.metricsRoute) {
             debug('Request to /metrics endpoint');
             res.set('Content-Type', Prometheus.register.contentType);
             return res.end(Prometheus.register.metrics());
         }
-        if (req.url === `${this.setupOptions.metricsRoute}.json`) {
+        if (routeUrl === `${this.setupOptions.metricsRoute}.json`) {
             debug('Request to /metrics endpoint');
             return res.json(Prometheus.register.getMetricsAsJSON());
         }
@@ -107,7 +110,7 @@ class ExpressMiddleware {
             contentLength: parseInt(req.get('content-length')) || 0
         };
 
-        debug(`Set start time and content length for request. url: ${req.url}, method: ${req.method}`);
+        debug(`Set start time and content length for request. url: ${routeUrl}, method: ${req.method}`);
 
         res.once('finish', () => {
             debug('on finish.');


### PR DESCRIPTION
`req.url` comes from NodeJS and doesn't provide the right value (`/` instead of `/metrics` or `/metrics.json`) to check the `metricsPath` against if `prometheus-api-metrics` is attached like this:

```node
const express = require('express')
const basicAuth = require('express-basic-auth')
const apiMetrics = require('prometheus-api-metrics')

const app = express()
const port = 3000

app.get('/', (req, res) => res.send('Hello World!'))

app.use(['/metrics', '/metrics.json'], basicAuth({ users: { foo: 'bar' } }), apiMetrics())

app.listen(port, () => console.log(`Example app listening at http://localhost:${port}`))
```

In this case, `req.url` is simply `/`. `req.originalUrl` is `/metrics` or `/metrics.json`. This PR will attempt to use `req.originalUrl` if set and fallback to `req.url`.

A workaround would be to simply set `metricsPath` to `/` but that both feels not great and doesn't work for the JSON path.

More info on [`req.originalUrl`](https://expressjs.com/en/api.html#req.originalUrl) from the ExpressJS docs