### PR TITLE
Fixed typo to enable strict mode

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-'use strics';
+'use strict';
 
 function getMetricNames(metricNames, useUniqueHistogramName, metricsPrefix, projectName) {
     const prefix = useUniqueHistogramName === true ? projectName : metricsPrefix;


### PR DESCRIPTION
There seems to be a typo in the first line. It should be "use strict".