### PR TITLE
Fix type error

### DIFF
--- a/src/express-middleware.js
+++ b/src/express-middleware.js
@@ -51,7 +51,7 @@ class ExpressMiddleware {
                 route = route ? route + req.route.path : req.route.path;
             }
 
-            if (!route || route === '') {
+            if (!route || route === '' || typeof route !== 'string') {
                 route = req.originalUrl.split('?')[0];
             } else {
                 const splittedRoute = route.split('/');


### PR DESCRIPTION
Trying to add metrics in EtherPad, I've been hitting with the following error:

```
03:53:51 0|front       | ^[[32m[2020-07-19 03:53:51.659] [INFO] console - ^[[39m/\/javascripts\/(.*)/ { fast_star: false, fast_slash: false }
03:53:51 0|front       | TypeError: route.split is not a function
03:53:51 0|front       |     at ExpressMiddleware._getRoute (/opt/app-root/src/node_modules/prometheus-api-metrics/src/express-middleware.js:69:45)
03:53:51 0|front       |     at ExpressMiddleware._handleResponse (/opt/app-root/src/node_modules/prometheus-api-metrics/src/express-middleware.js:37:2
03:53:51 0|front       |     at ServerResponse.<anonymous> (/opt/app-root/src/node_modules/prometheus-api-metrics/src/express-middleware.js:129:18)
03:53:51 0|front       |     at Object.onceWrapper (events.js:421:28)
03:53:51 0|front       |     at ServerResponse.emit (events.js:327:22)
03:53:51 0|front       |     at ServerResponse.EventEmitter.emit (domain.js:482:12)
03:53:51 0|front       |     at onFinish (_http_outgoing.js:723:10)
03:53:51 0|front       |     at onCorkedFinish (_stream_writable.js:673:5)
03:53:51 0|front       |     at afterWrite (_stream_writable.js:490:5)
03:53:51 0|front       |     at afterWriteTick (_stream_writable.js:477:10)
03:53:51 0|front       | ^[[31m[2020-07-19 03:53:51.661] [ERROR] console - ^[[39mTypeError: route.split is not a function
03:53:51 0|front       |     at ExpressMiddleware._getRoute (/opt/app-root/src/node_modules/prometheus-api-metrics/src/express-middleware.js:69:45)
03:53:51 0|front       |     at ExpressMiddleware._handleResponse (/opt/app-root/src/node_modules/prometheus-api-metrics/src/express-middleware.js:37:2
03:53:51 0|front       |     at ServerResponse.<anonymous> (/opt/app-root/src/node_modules/prometheus-api-metrics/src/express-middleware.js:129:18)
03:53:51 0|front       |     at Object.onceWrapper (events.js:421:28)
03:53:51 0|front       |     at ServerResponse.emit (events.js:327:22)
03:53:51 0|front       |     at ServerResponse.EventEmitter.emit (domain.js:482:12)
03:53:51 0|front       |     at onFinish (_http_outgoing.js:723:10)
03:53:51 0|front       |     at onCorkedFinish (_stream_writable.js:673:5)
03:53:51 0|front       |     at afterWrite (_stream_writable.js:490:5)
03:53:51 0|front       |     at afterWriteTick (_stream_writable.js:477:10)
```

(line numbers above might be off, as I've been adding debugs...)

The `route.split` on line 57 would fail, as `route` is an object (`/\/javascripts\/(.*)/ { fast_star: false, fast_slash: false }`.
This could be avoided, checking `typeof route`