### PR TITLE
feat: Support for metrics custom labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Master
 
-- Add `additionalLabels` and `extractAdditionalLabelValuesFn` options, see [README](README.md) for more info.
+### Features
+
+- Add support for custom labels addition to metrics
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master
 
+- Add `additionalLabels` and `extractAdditionalLabelValuesFn` options, see [README](README.md) for more info.
+
 ### Breaking Changes
 
 - Add support for `prom-client v13`, which includes a few breaking changes, mainly the following functions are now async (return a promise):

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ app.use(apiMetrics())
 - metricsPrefix - A custom metrics names prefix, the package will add underscore between your prefix to the metric name.
 - excludeRoutes - Array of routes to exclude. Routes should be in your framework syntax.
 - includeQueryParams - A boolean that indicate if to include query params in route, the query parameters will be sorted in order to eliminate the number of unique labels.
-- metricsExtraLabels - An array of strings indicating custom metrics that can be included to each `http_*` metric. Use in conjunction with `getMetricsExtraLabelValues`.
-- getMetricsExtraLabelValues - A function that can be use to generate the value of custom labels for each of the `http_*` metric.
+- metricAdditionalLabels - An array of strings indicating custom metrics that can be included to each `http_*` metric. Use in conjunction with `getMetricsAdditionalLabelValues`.
+- getMetricsAdditionalLabelValues - A function that can be use to generate the value of custom labels for each of the `http_*` metric. When using koa, the function takes `ctx`, when using express, it takes `req, res` as arguments.
 
 ### Access the metrics
 

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ app.use(apiMetrics())
 | `metricsPrefix`          | `String`  | A custom metrics names prefix, the package will add underscore between your prefix to the metric name | |
 | `excludeRoutes`          | `Array<String>` | Array of routes to exclude. Routes should be in your framework syntax | |
 | `includeQueryParams`     | `Boolean` | Indicate if to include query params in route, the query parameters will be sorted in order to eliminate the number of unique labels | `false` |
-| `metricAdditionalLabels`          | `Array<string>` | Indicating custom metrics that can be included to each `http_*` metric. Use in conjunction with `getMetricsAdditionalLabelValues`. |
-| `getMetricsAdditionalLabelValues` | `Function`      | A function that can be use to generate the value of custom labels for each of the `http_*` metric. When using koa, the function takes `ctx`, when using express, it takes `req, res` as arguments | |
+| `metricAdditionalLabels`          | `Array<string>` | Indicating custom metrics that can be included to each `http_*` metric. Use in conjunction with `getMetricAdditionalLabelValues`. |
+| `getMetricAdditionalLabelValues` | `Function`      | A function that can be use to generate the value of custom labels for each of the `http_*` metric. When using koa, the function takes `ctx`, when using express, it takes `req, res` as arguments | |
 
 ### Access the metrics
 

--- a/README.md
+++ b/README.md
@@ -38,16 +38,16 @@ API and process monitoring with [Prometheus](https://prometheus.io) for Node.js 
 ## Features
 
 - [Collect API metrics for each call](#usage)
-   - Response time in seconds
-   - Request size in bytes
-   - Response size in bytes
-   - Add prefix to metrics names - custom or project name
-   - Exclude specific routes from being collect
-   - Number of open connections to the server
+  - Response time in seconds
+  - Request size in bytes
+  - Response size in bytes
+  - Add prefix to metrics names - custom or project name
+  - Exclude specific routes from being collect
+  - Number of open connections to the server
 - Process Metrics as recommended by Prometheus [itself](https://prometheus.io/docs/instrumenting/writing_clientlibs/#standard-and-runtime-collectors)
 - Endpoint to retrieve the metrics - used for Prometheus scraping
-   - Prometheus format
-   - JSON format (`${path}.json`)
+  - Prometheus format
+  - JSON format (`${path}.json`)
 - Support custom metrics
 - [Http function to collect request.js HTTP request duration](#requestjs-http-request-duration-collector)
 
@@ -162,7 +162,6 @@ HttpMetricsCollector.init();
 - useUniqueHistogramName - Add to metrics names the project name as a prefix (from package.json)
 - prefix - A custom metrics names prefix, the package will add underscore between your prefix to the metric name.
 
-
 For Example:
 
 #### request
@@ -182,7 +181,6 @@ return requestPromise({ method: 'POST', url: 'http://www.mocky.io/v2/5bd9984b2f0
     Collector.collect(error);
 });
 ```
-
 
 **Notes:**
 
@@ -212,7 +210,7 @@ try {
 
 **Notes:**
 
-* In order to collect metrics from axios client the [`axios-time`](https://www.npmjs.com/package/axios-time) package is required.
+- In order to collect metrics from axios client the [`axios-time`](https://www.npmjs.com/package/axios-time) package is required.
 
 ## Usage in koa
 

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ app.use(apiMetrics())
 | `metricsPrefix`          | `String`  | A custom metrics names prefix, the package will add underscore between your prefix to the metric name | |
 | `excludeRoutes`          | `Array<String>` | Array of routes to exclude. Routes should be in your framework syntax | |
 | `includeQueryParams`     | `Boolean` | Indicate if to include query params in route, the query parameters will be sorted in order to eliminate the number of unique labels | `false` |
-| `metricAdditionalLabels`         | `Array<String>` | Indicating custom labels that can be included on each `http_*` metric. Use in conjunction with `getMetricAdditionalLabelValues`. |
-| `getMetricAdditionalLabelValues` | `Function`      | A function that can be use to generate the value of custom labels for each of the `http_*` metrics. When using koa, the function takes `ctx`, when using express, it takes `req, res` as arguments | |
+| `additionalLabels`       | `Array<String>` | Indicating custom labels that can be included on each `http_*` metric. Use in conjunction with `extractAdditionalLabelValuesFn`. |
+| `extractAdditionalLabelValuesFn` | `Function`      | A function that can be use to generate the value of custom labels for each of the `http_*` metrics. When using koa, the function takes `ctx`, when using express, it takes `req, res` as arguments | |
 
 ### Access the metrics
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ app.use(apiMetrics())
 | `excludeRoutes`          | `Array<String>` | Array of routes to exclude. Routes should be in your framework syntax | |
 | `includeQueryParams`     | `Boolean` | Indicate if to include query params in route, the query parameters will be sorted in order to eliminate the number of unique labels | `false` |
 | `metricAdditionalLabels`         | `Array<String>` | Indicating custom metrics that can be included to each `http_*` metric. Use in conjunction with `getMetricAdditionalLabelValues`. |
-| `getMetricAdditionalLabelValues` | `Function`      | A function that can be use to generate the value of custom labels for each of the `http_*` metric. When using koa, the function takes `ctx`, when using express, it takes `req, res` as arguments | |
+| `getMetricAdditionalLabelValues` | `Function`      | A function that can be use to generate the value of custom labels for each of the `http_*` metrics. When using koa, the function takes `ctx`, when using express, it takes `req, res` as arguments | |
 
 ### Access the metrics
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ app.use(apiMetrics())
 | `metricsPrefix`          | `String`  | A custom metrics names prefix, the package will add underscore between your prefix to the metric name | |
 | `excludeRoutes`          | `Array<String>` | Array of routes to exclude. Routes should be in your framework syntax | |
 | `includeQueryParams`     | `Boolean` | Indicate if to include query params in route, the query parameters will be sorted in order to eliminate the number of unique labels | `false` |
-| `metricAdditionalLabels`         | `Array<String>` | Indicating custom metrics that can be included to each `http_*` metric. Use in conjunction with `getMetricAdditionalLabelValues`. |
+| `metricAdditionalLabels`         | `Array<String>` | Indicating custom labels that can be included on each `http_*` metric. Use in conjunction with `getMetricAdditionalLabelValues`. |
 | `getMetricAdditionalLabelValues` | `Function`      | A function that can be use to generate the value of custom labels for each of the `http_*` metrics. When using koa, the function takes `ctx`, when using express, it takes `req, res` as arguments | |
 
 ### Access the metrics

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ app.use(apiMetrics())
 | `metricsPrefix`          | `String`  | A custom metrics names prefix, the package will add underscore between your prefix to the metric name | |
 | `excludeRoutes`          | `Array<String>` | Array of routes to exclude. Routes should be in your framework syntax | |
 | `includeQueryParams`     | `Boolean` | Indicate if to include query params in route, the query parameters will be sorted in order to eliminate the number of unique labels | `false` |
-| `metricAdditionalLabels`          | `Array<string>` | Indicating custom metrics that can be included to each `http_*` metric. Use in conjunction with `getMetricAdditionalLabelValues`. |
+| `metricAdditionalLabels`         | `Array<string>` | Indicating custom metrics that can be included to each `http_*` metric. Use in conjunction with `getMetricAdditionalLabelValues`. |
 | `getMetricAdditionalLabelValues` | `Function`      | A function that can be use to generate the value of custom labels for each of the `http_*` metric. When using koa, the function takes `ctx`, when using express, it takes `req, res` as arguments | |
 
 ### Access the metrics

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ app.use(apiMetrics())
 | `excludeRoutes`          | `Array<String>` | Array of routes to exclude. Routes should be in your framework syntax | |
 | `includeQueryParams`     | `Boolean` | Indicate if to include query params in route, the query parameters will be sorted in order to eliminate the number of unique labels | `false` |
 | `additionalLabels`       | `Array<String>` | Indicating custom labels that can be included on each `http_*` metric. Use in conjunction with `extractAdditionalLabelValuesFn`. |
-| `extractAdditionalLabelValuesFn` | `Function`      | A function that can be use to generate the value of custom labels for each of the `http_*` metrics. When using koa, the function takes `ctx`, when using express, it takes `req, res` as arguments | |
+| `extractAdditionalLabelValuesFn` | `Function` | A function that can be use to generate the value of custom labels for each of the `http_*` metrics. When using koa, the function takes `ctx`, when using express, it takes `req, res` as arguments | |
 
 ### Access the metrics
 
@@ -93,7 +93,6 @@ curl http[s]://<host>:[port]/metrics.json
 1. If you pass to the middleware the `metricsPath` option the path will be the one that you chose.
 
 2. If you are using express framework and no route was found for the request (e.g: 404 status code), the request will not be collected. that's because we'll risk memory leak since the route is not a pattern but a hardcoded string.
-
 
 ## Custom Metrics
 
@@ -131,6 +130,26 @@ For more info about the Node.js Prometheus client you can read [here](https://gi
 ### Note
 
 This will work only if you use the default Prometheus registry - do not use `new Prometheus.Registry()`
+
+## Additional Metric Labels
+
+You can define additional metric labels by using `additionalLabels` and `extractAdditionalLabelValuesFn` options.
+
+For instance:
+
+```js
+const apiMetrics = require('prometheus-api-metrics');
+app.use(apiMetrics({
+  additionalLabels: ['customer', 'cluster'],
+  extractAdditionalLabelValuesFn: (req, res) => {
+      const { headers } = req.headers;
+      return {
+        customer: headers['x-custom-header-customer'],
+        cluster: headers['x-custom-header-cluster']
+      }
+  }
+}))
+```
 
 ## Request.js HTTP request duration collector
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ app.use(apiMetrics())
 | `metricsPrefix`          | `String`  | A custom metrics names prefix, the package will add underscore between your prefix to the metric name | |
 | `excludeRoutes`          | `Array<String>` | Array of routes to exclude. Routes should be in your framework syntax | |
 | `includeQueryParams`     | `Boolean` | Indicate if to include query params in route, the query parameters will be sorted in order to eliminate the number of unique labels | `false` |
-| `metricAdditionalLabels`         | `Array<string>` | Indicating custom metrics that can be included to each `http_*` metric. Use in conjunction with `getMetricAdditionalLabelValues`. |
+| `metricAdditionalLabels`         | `Array<String>` | Indicating custom metrics that can be included to each `http_*` metric. Use in conjunction with `getMetricAdditionalLabelValues`. |
 | `getMetricAdditionalLabelValues` | `Function`      | A function that can be use to generate the value of custom labels for each of the `http_*` metric. When using koa, the function takes `ctx`, when using express, it takes `req, res` as arguments | |
 
 ### Access the metrics

--- a/README.md
+++ b/README.md
@@ -60,17 +60,19 @@ app.use(apiMetrics())
 
 ### Options
 
-- metricsPath - Path to access the metrics. `default: /metrics`
-- defaultMetricsInterval - the interval to collect the process metrics in milliseconds. `default: 10000`
-- durationBuckets - Buckets for response time in seconds. `default: [0.001, 0.005, 0.015, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5]`
-- requestSizeBuckets - Buckets for request size in bytes. `default: [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000]`
-- responseSizeBuckets - Buckets for response size in bytes. `default: [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000]`
-- useUniqueHistogramName - Add to metrics names the project name as a prefix (from package.json)
-- metricsPrefix - A custom metrics names prefix, the package will add underscore between your prefix to the metric name.
-- excludeRoutes - Array of routes to exclude. Routes should be in your framework syntax.
-- includeQueryParams - A boolean that indicate if to include query params in route, the query parameters will be sorted in order to eliminate the number of unique labels.
-- metricAdditionalLabels - An array of strings indicating custom metrics that can be included to each `http_*` metric. Use in conjunction with `getMetricsAdditionalLabelValues`.
-- getMetricsAdditionalLabelValues - A function that can be use to generate the value of custom labels for each of the `http_*` metric. When using koa, the function takes `ctx`, when using express, it takes `req, res` as arguments.
+| Option                   | Type      | Description | Default Value |
+|--------------------------|-----------|-------------|---------------|
+| `metricsPath`            | `String`  | Path to access the metrics | `/metrics` |
+| `defaultMetricsInterval` | `Number`  | Interval to collect the process metrics in milliseconds | `10000` |
+| `durationBuckets`        | `Array<Number>` | Buckets for response time in seconds | `[0.001, 0.005, 0.015, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5]` |
+| `requestSizeBuckets`     | `Array<Number>` | Buckets for request size in bytes | `[5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000]` |
+| `responseSizeBuckets`    | `Array<Number>` | Buckets for response size in bytes | `[5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000]` |
+| `useUniqueHistogramName` | `Boolean` | Add to metrics names the project name as a prefix (from package.json) | `false` |
+| `metricsPrefix`          | `String`  | A custom metrics names prefix, the package will add underscore between your prefix to the metric name | |
+| `excludeRoutes`          | `Array<String>` | Array of routes to exclude. Routes should be in your framework syntax | |
+| `includeQueryParams`     | `Boolean` | Indicate if to include query params in route, the query parameters will be sorted in order to eliminate the number of unique labels | `false` |
+| `metricAdditionalLabels`          | `Array<string>` | Indicating custom metrics that can be included to each `http_*` metric. Use in conjunction with `getMetricsAdditionalLabelValues`. |
+| `getMetricsAdditionalLabelValues` | `Function`      | A function that can be use to generate the value of custom labels for each of the `http_*` metric. When using koa, the function takes `ctx`, when using express, it takes `req, res` as arguments | |
 
 ### Access the metrics
 

--- a/src/express-middleware.js
+++ b/src/express-middleware.js
@@ -40,11 +40,12 @@ class ExpressMiddleware {
             const labels = {
                 route,
                 code: res.statusCode,
-                ...this.setupOptions.getMetricsExtraLabelValues(req, res)
+                method: req.method,
+                ...this.setupOptions.getMetricsAdditionalLabelValues(req, res)
             };
-            this.setupOptions.requestSizeHistogram.observe({ method: req.method, ...labels }, req.metrics.contentLength);
+            this.setupOptions.requestSizeHistogram.observe(labels, req.metrics.contentLength);
             req.metrics.timer(labels);
-            this.setupOptions.responseSizeHistogram.observe({ method: req.method, ...labels }, responseLength);
+            this.setupOptions.responseSizeHistogram.observe(labels, responseLength);
             debug(`metrics updated, request length: ${req.metrics.contentLength}, response length: ${responseLength}`);
         }
     }
@@ -109,9 +110,7 @@ class ExpressMiddleware {
         }
 
         req.metrics = {
-            timer: this.setupOptions.responseTimeHistogram.startTimer({
-                method: req.method
-            }),
+            timer: this.setupOptions.responseTimeHistogram.startTimer(),
             contentLength: parseInt(req.get('content-length')) || 0
         };
 

--- a/src/express-middleware.js
+++ b/src/express-middleware.js
@@ -37,9 +37,14 @@ class ExpressMiddleware {
         const route = this._getRoute(req);
 
         if (route && utils.shouldLogMetrics(this.setupOptions.excludeRoutes, route)) {
-            this.setupOptions.requestSizeHistogram.observe({ method: req.method, route: route, code: res.statusCode }, req.metrics.contentLength);
-            req.metrics.timer({ route: route, code: res.statusCode });
-            this.setupOptions.responseSizeHistogram.observe({ method: req.method, route: route, code: res.statusCode }, responseLength);
+            const labels = {
+                code: res.statusCode,
+                route,
+                ...this.setupOptions.getMetricsExtraLabelValues(req, res)
+            };
+            this.setupOptions.requestSizeHistogram.observe({ method: req.method, ...labels }, req.metrics.contentLength);
+            req.metrics.timer(labels);
+            this.setupOptions.responseSizeHistogram.observe({ method: req.method, ...labels }, responseLength);
             debug(`metrics updated, request length: ${req.metrics.contentLength}, response length: ${responseLength}`);
         }
     }

--- a/src/express-middleware.js
+++ b/src/express-middleware.js
@@ -38,8 +38,8 @@ class ExpressMiddleware {
 
         if (route && utils.shouldLogMetrics(this.setupOptions.excludeRoutes, route)) {
             const labels = {
-                code: res.statusCode,
                 route,
+                code: res.statusCode,
                 ...this.setupOptions.getMetricsExtraLabelValues(req, res)
             };
             this.setupOptions.requestSizeHistogram.observe({ method: req.method, ...labels }, req.metrics.contentLength);

--- a/src/express-middleware.js
+++ b/src/express-middleware.js
@@ -41,7 +41,7 @@ class ExpressMiddleware {
                 method: req.method,
                 route,
                 code: res.statusCode,
-                ...this.setupOptions.getMetricsAdditionalLabelValues(req, res)
+                ...this.setupOptions.getMetricAdditionalLabelValues(req, res)
             };
             this.setupOptions.requestSizeHistogram.observe(labels, req.metrics.contentLength);
             req.metrics.timer(labels);

--- a/src/express-middleware.js
+++ b/src/express-middleware.js
@@ -41,7 +41,7 @@ class ExpressMiddleware {
                 method: req.method,
                 route,
                 code: res.statusCode,
-                ...this.setupOptions.getMetricAdditionalLabelValues(req, res)
+                ...this.setupOptions.extractAdditionalLabelValuesFn(req, res)
             };
             this.setupOptions.requestSizeHistogram.observe(labels, req.metrics.contentLength);
             req.metrics.timer(labels);

--- a/src/express-middleware.js
+++ b/src/express-middleware.js
@@ -38,9 +38,9 @@ class ExpressMiddleware {
 
         if (route && utils.shouldLogMetrics(this.setupOptions.excludeRoutes, route)) {
             const labels = {
+                method: req.method,
                 route,
                 code: res.statusCode,
-                method: req.method,
                 ...this.setupOptions.getMetricsAdditionalLabelValues(req, res)
             };
             this.setupOptions.requestSizeHistogram.observe(labels, req.metrics.contentLength);

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,5 @@
-import { RequestHandler, Response } from 'express';
-import { Middleware } from 'koa';
+import { Request, RequestHandler, Response } from 'express';
+import { Context, Middleware } from 'koa';
 
 export default function middleware(options?: ApiMetricsOpts) : RequestHandler;
 export function koaMiddleware(options?: ApiMetricsOpts) : Middleware;
@@ -20,6 +20,8 @@ export interface ApiMetricsOpts {
   metricsPrefix?: string;
   excludeRoutes?:string[];
   includeQueryParams?: boolean;
+  metricsExtraLabels?: [];
+  getMetricsExtraLabelValues?: ((req: Request, res: Response) => Record<string, unknown>) | ((ctx: Context) => Record<string, unknown>)
 }
 
 export interface CollectorOpts {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -20,8 +20,8 @@ export interface ApiMetricsOpts {
   metricsPrefix?: string;
   excludeRoutes?:string[];
   includeQueryParams?: boolean;
-  metricAdditionalLabels?: string[];
-  getMetricAdditionalLabelValues?: ((req: Request, res: Response) => Record<string, unknown>) | ((ctx: Context) => Record<string, unknown>)
+  additionalLabels?: string[];
+  extractAdditionalLabelValuesFn?: ((req: Request, res: Response) => Record<string, unknown>) | ((ctx: Context) => Record<string, unknown>)
 }
 
 export interface CollectorOpts {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -20,8 +20,8 @@ export interface ApiMetricsOpts {
   metricsPrefix?: string;
   excludeRoutes?:string[];
   includeQueryParams?: boolean;
-  metricsExtraLabels?: string[];
-  getMetricsExtraLabelValues?: ((req: Request, res: Response) => Record<string, unknown>) | ((ctx: Context) => Record<string, unknown>)
+  metricAdditionalLabels?: string[];
+  getMetricsAdditionalLabelValues?: ((req: Request, res: Response) => Record<string, unknown>) | ((ctx: Context) => Record<string, unknown>)
 }
 
 export interface CollectorOpts {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -20,7 +20,7 @@ export interface ApiMetricsOpts {
   metricsPrefix?: string;
   excludeRoutes?:string[];
   includeQueryParams?: boolean;
-  metricsExtraLabels?: [];
+  metricsExtraLabels?: string[];
   getMetricsExtraLabelValues?: ((req: Request, res: Response) => Record<string, unknown>) | ((ctx: Context) => Record<string, unknown>)
 }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -21,7 +21,7 @@ export interface ApiMetricsOpts {
   excludeRoutes?:string[];
   includeQueryParams?: boolean;
   metricAdditionalLabels?: string[];
-  getMetricsAdditionalLabelValues?: ((req: Request, res: Response) => Record<string, unknown>) | ((ctx: Context) => Record<string, unknown>)
+  getMetricAdditionalLabelValues?: ((req: Request, res: Response) => Record<string, unknown>) | ((ctx: Context) => Record<string, unknown>)
 }
 
 export interface CollectorOpts {

--- a/src/koa-middleware.js
+++ b/src/koa-middleware.js
@@ -40,8 +40,8 @@ class KoaMiddleware {
 
         if (route && utils.shouldLogMetrics(this.setupOptions.excludeRoutes, route)) {
             const labels = {
-                code: ctx.res.statusCode,
                 route,
+                code: ctx.res.statusCode,
                 ...this.setupOptions.getMetricsExtraLabelValues(ctx)
             };
             this.setupOptions.requestSizeHistogram.observe({

--- a/src/koa-middleware.js
+++ b/src/koa-middleware.js
@@ -42,17 +42,12 @@ class KoaMiddleware {
             const labels = {
                 route,
                 code: ctx.res.statusCode,
-                ...this.setupOptions.getMetricsExtraLabelValues(ctx)
+                method: ctx.req.method,
+                ...this.setupOptions.getMetricsAdditionalLabelValues(ctx)
             };
-            this.setupOptions.requestSizeHistogram.observe({
-                method: ctx.req.method,
-                ...labels
-            }, ctx.req.metrics.contentLength);
+            this.setupOptions.requestSizeHistogram.observe(labels, ctx.req.metrics.contentLength);
             ctx.req.metrics.timer(labels);
-            this.setupOptions.responseSizeHistogram.observe({
-                method: ctx.req.method,
-                ...labels
-            }, responseLength);
+            this.setupOptions.responseSizeHistogram.observe(labels, responseLength);
             debug(`metrics updated, request length: ${ctx.req.metrics.contentLength}, response length: ${responseLength}`);
         }
     }
@@ -125,9 +120,7 @@ class KoaMiddleware {
         }
 
         ctx.req.metrics = {
-            timer: this.setupOptions.responseTimeHistogram.startTimer({
-                method: ctx.req.method
-            }),
+            timer: this.setupOptions.responseTimeHistogram.startTimer(),
             contentLength: parseInt(ctx.request.get('content-length')) || 0
         };
 

--- a/src/koa-middleware.js
+++ b/src/koa-middleware.js
@@ -43,7 +43,7 @@ class KoaMiddleware {
                 method: ctx.req.method,
                 route,
                 code: ctx.res.statusCode,
-                ...this.setupOptions.getMetricAdditionalLabelValues(ctx)
+                ...this.setupOptions.extractAdditionalLabelValuesFn(ctx)
             };
             this.setupOptions.requestSizeHistogram.observe(labels, ctx.req.metrics.contentLength);
             ctx.req.metrics.timer(labels);

--- a/src/koa-middleware.js
+++ b/src/koa-middleware.js
@@ -40,9 +40,9 @@ class KoaMiddleware {
 
         if (route && utils.shouldLogMetrics(this.setupOptions.excludeRoutes, route)) {
             const labels = {
+                method: ctx.req.method,
                 route,
                 code: ctx.res.statusCode,
-                method: ctx.req.method,
                 ...this.setupOptions.getMetricsAdditionalLabelValues(ctx)
             };
             this.setupOptions.requestSizeHistogram.observe(labels, ctx.req.metrics.contentLength);

--- a/src/koa-middleware.js
+++ b/src/koa-middleware.js
@@ -43,7 +43,7 @@ class KoaMiddleware {
                 method: ctx.req.method,
                 route,
                 code: ctx.res.statusCode,
-                ...this.setupOptions.getMetricsAdditionalLabelValues(ctx)
+                ...this.setupOptions.getMetricAdditionalLabelValues(ctx)
             };
             this.setupOptions.requestSizeHistogram.observe(labels, ctx.req.metrics.contentLength);
             ctx.req.metrics.timer(labels);

--- a/src/koa-middleware.js
+++ b/src/koa-middleware.js
@@ -39,16 +39,19 @@ class KoaMiddleware {
         const route = this._getRoute(ctx) || 'N/A';
 
         if (route && utils.shouldLogMetrics(this.setupOptions.excludeRoutes, route)) {
+            const labels = {
+                code: ctx.res.statusCode,
+                route,
+                ...this.setupOptions.getMetricsExtraLabelValues(ctx)
+            };
             this.setupOptions.requestSizeHistogram.observe({
                 method: ctx.req.method,
-                route: route,
-                code: ctx.res.statusCode
+                ...labels
             }, ctx.req.metrics.contentLength);
-            ctx.req.metrics.timer({ route: route, code: ctx.res.statusCode });
+            ctx.req.metrics.timer(labels);
             this.setupOptions.responseSizeHistogram.observe({
                 method: ctx.req.method,
-                route: route,
-                code: ctx.res.statusCode
+                ...labels
             }, responseLength);
             debug(`metrics updated, request length: ${ctx.req.metrics.contentLength}, response length: ${responseLength}`);
         }

--- a/src/metrics-middleware.js
+++ b/src/metrics-middleware.js
@@ -21,7 +21,7 @@ module.exports = (appVersion, projectName, framework = 'express') => {
             excludeRoutes,
             includeQueryParams,
             metricAdditionalLabels = [],
-            getMetricsAdditionalLabelValues
+            getMetricAdditionalLabelValues
         } = options;
         debug(`Init metrics middleware with options: ${JSON.stringify(options)}`);
 
@@ -49,11 +49,11 @@ module.exports = (appVersion, projectName, framework = 'express') => {
             errorMessage: 'metricAdditionalLabels should be an array'
         });
 
-        setupOptions.getMetricsAdditionalLabelValues = utils.validateInput({
-            input: getMetricsAdditionalLabelValues,
+        setupOptions.getMetricAdditionalLabelValues = utils.validateInput({
+            input: getMetricAdditionalLabelValues,
             isValidInputFn: utils.isFunction,
             defaultValue: () => ({}),
-            errorMessage: 'getMetricsAdditionalLabelValues should be a function'
+            errorMessage: 'getMetricAdditionalLabelValues should be a function'
         });
 
         const metricNames = utils.getMetricNames(

--- a/src/metrics-middleware.js
+++ b/src/metrics-middleware.js
@@ -20,16 +20,41 @@ module.exports = (appVersion, projectName, framework = 'express') => {
             metricsPrefix,
             excludeRoutes,
             includeQueryParams,
-            metricsExtraLabels = [],
-            getMetricsExtraLabelValues
+            metricAdditionalLabels = [],
+            getMetricsAdditionalLabelValues
         } = options;
         debug(`Init metrics middleware with options: ${JSON.stringify(options)}`);
-        setupOptions.metricsRoute = metricsPath || '/metrics';
-        setupOptions.excludeRoutes = excludeRoutes || [];
+
+        setupOptions.metricsRoute = utils.validateInput({
+            input: metricsPath,
+            isValidInputFn: utils.isString,
+            defaultValue: '/metrics',
+            errorMessage: 'metricsPath should be an string'
+        });
+
+        setupOptions.excludeRoutes = utils.validateInput({
+            input: excludeRoutes,
+            isValidInputFn: utils.isArray,
+            defaultValue: [],
+            errorMessage: 'excludeRoutes should be an array'
+        });
+
         setupOptions.includeQueryParams = includeQueryParams;
         setupOptions.defaultMetricsInterval = defaultMetricsInterval;
-        setupOptions.metricsExtraLabels = metricsExtraLabels || [];
-        setupOptions.getMetricsExtraLabelValues = typeof getMetricsExtraLabelValues === 'function' ? getMetricsExtraLabelValues : () => ({});
+
+        setupOptions.metricAdditionalLabels = utils.validateInput({
+            input: metricAdditionalLabels,
+            isValidInputFn: utils.isArray,
+            defaultValue: [],
+            errorMessage: 'metricAdditionalLabels should be an array'
+        });
+
+        setupOptions.getMetricsAdditionalLabelValues = utils.validateInput({
+            input: getMetricsAdditionalLabelValues,
+            isValidInputFn: utils.isFunction,
+            defaultValue: () => ({}),
+            errorMessage: 'getMetricsAdditionalLabelValues should be a function'
+        });
 
         const metricNames = utils.getMetricNames(
             {
@@ -52,7 +77,7 @@ module.exports = (appVersion, projectName, framework = 'express') => {
             'method',
             'route',
             'code',
-            ...Array.isArray(metricsExtraLabels) ? metricsExtraLabels : []
+            ...metricAdditionalLabels
         ].filter(Boolean);
 
         const defaultSizeBuckets = [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000];

--- a/src/metrics-middleware.js
+++ b/src/metrics-middleware.js
@@ -20,8 +20,8 @@ module.exports = (appVersion, projectName, framework = 'express') => {
             metricsPrefix,
             excludeRoutes,
             includeQueryParams,
-            metricAdditionalLabels = [],
-            getMetricAdditionalLabelValues
+            additionalLabels = [],
+            extractAdditionalLabelValuesFn
         } = options;
         debug(`Init metrics middleware with options: ${JSON.stringify(options)}`);
 
@@ -42,18 +42,18 @@ module.exports = (appVersion, projectName, framework = 'express') => {
         setupOptions.includeQueryParams = includeQueryParams;
         setupOptions.defaultMetricsInterval = defaultMetricsInterval;
 
-        setupOptions.metricAdditionalLabels = utils.validateInput({
-            input: metricAdditionalLabels,
+        setupOptions.additionalLabels = utils.validateInput({
+            input: additionalLabels,
             isValidInputFn: utils.isArray,
             defaultValue: [],
-            errorMessage: 'metricAdditionalLabels should be an array'
+            errorMessage: 'additionalLabels should be an array'
         });
 
-        setupOptions.getMetricAdditionalLabelValues = utils.validateInput({
-            input: getMetricAdditionalLabelValues,
+        setupOptions.extractAdditionalLabelValuesFn = utils.validateInput({
+            input: extractAdditionalLabelValuesFn,
             isValidInputFn: utils.isFunction,
             defaultValue: () => ({}),
-            errorMessage: 'getMetricAdditionalLabelValues should be a function'
+            errorMessage: 'extractAdditionalLabelValuesFn should be a function'
         });
 
         const metricNames = utils.getMetricNames(
@@ -77,7 +77,7 @@ module.exports = (appVersion, projectName, framework = 'express') => {
             'method',
             'route',
             'code',
-            ...metricAdditionalLabels
+            ...additionalLabels
         ].filter(Boolean);
 
         // Buckets for response time from 1ms to 500ms

--- a/src/metrics-middleware.js
+++ b/src/metrics-middleware.js
@@ -28,7 +28,8 @@ module.exports = (appVersion, projectName, framework = 'express') => {
         setupOptions.excludeRoutes = excludeRoutes || [];
         setupOptions.includeQueryParams = includeQueryParams;
         setupOptions.defaultMetricsInterval = defaultMetricsInterval;
-        setupOptions.getMetricsExtraLabelValues = typeof getLabelValues === 'function' ? getMetricsExtraLabelValues : () => ({});
+        setupOptions.metricsExtraLabels = metricsExtraLabels || [];
+        setupOptions.getMetricsExtraLabelValues = typeof getMetricsExtraLabelValues === 'function' ? getMetricsExtraLabelValues : () => ({});
 
         const metricNames = utils.getMetricNames(
             {

--- a/src/metrics-middleware.js
+++ b/src/metrics-middleware.js
@@ -80,28 +80,29 @@ module.exports = (appVersion, projectName, framework = 'express') => {
             ...metricAdditionalLabels
         ].filter(Boolean);
 
-        const defaultSizeBuckets = [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000];
+        const defaultDurationMsBuckets = [0.001, 0.005, 0.015, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5];
+        const defaultSizeBytesBuckets = [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000];
 
         setupOptions.responseTimeHistogram = Prometheus.register.getSingleMetric(metricNames.http_request_duration_seconds) || new Prometheus.Histogram({
             name: metricNames.http_request_duration_seconds,
             help: 'Duration of HTTP requests in seconds',
             labelNames: metricLabels,
             // buckets for response time from 1ms to 500ms
-            buckets: durationBuckets || [0.001, 0.005, 0.015, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5]
+            buckets: durationBuckets || defaultDurationMsBuckets
         });
 
         setupOptions.requestSizeHistogram = Prometheus.register.getSingleMetric(metricNames.http_request_size_bytes) || new Prometheus.Histogram({
             name: metricNames.http_request_size_bytes,
             help: 'Size of HTTP requests in bytes',
             labelNames: metricLabels,
-            buckets: requestSizeBuckets || defaultSizeBuckets // buckets for request size from 5 bytes to 10000 bytes
+            buckets: requestSizeBuckets || defaultSizeBytesBuckets // buckets for request size from 5 bytes to 10000 bytes
         });
 
         setupOptions.responseSizeHistogram = Prometheus.register.getSingleMetric(metricNames.http_response_size_bytes) || new Prometheus.Histogram({
             name: metricNames.http_response_size_bytes,
             help: 'Size of HTTP response in bytes',
             labelNames: metricLabels,
-            buckets: responseSizeBuckets || defaultSizeBuckets // buckets for response size from 5 bytes to 10000 bytes
+            buckets: responseSizeBuckets || defaultSizeBytesBuckets // buckets for response size from 5 bytes to 10000 bytes
         });
 
         return frameworkMiddleware(framework);

--- a/src/metrics-middleware.js
+++ b/src/metrics-middleware.js
@@ -80,29 +80,30 @@ module.exports = (appVersion, projectName, framework = 'express') => {
             ...metricAdditionalLabels
         ].filter(Boolean);
 
-        const defaultDurationMsBuckets = [0.001, 0.005, 0.015, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5];
+        // Buckets for response time from 1ms to 500ms
+        const defaultDurationSecondsBuckets = [0.001, 0.005, 0.015, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5];
+        // Buckets for request size from 5 bytes to 10000 bytes
         const defaultSizeBytesBuckets = [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000];
 
         setupOptions.responseTimeHistogram = Prometheus.register.getSingleMetric(metricNames.http_request_duration_seconds) || new Prometheus.Histogram({
             name: metricNames.http_request_duration_seconds,
             help: 'Duration of HTTP requests in seconds',
             labelNames: metricLabels,
-            // buckets for response time from 1ms to 500ms
-            buckets: durationBuckets || defaultDurationMsBuckets
+            buckets: durationBuckets || defaultDurationSecondsBuckets
         });
 
         setupOptions.requestSizeHistogram = Prometheus.register.getSingleMetric(metricNames.http_request_size_bytes) || new Prometheus.Histogram({
             name: metricNames.http_request_size_bytes,
             help: 'Size of HTTP requests in bytes',
             labelNames: metricLabels,
-            buckets: requestSizeBuckets || defaultSizeBytesBuckets // buckets for request size from 5 bytes to 10000 bytes
+            buckets: requestSizeBuckets || defaultSizeBytesBuckets
         });
 
         setupOptions.responseSizeHistogram = Prometheus.register.getSingleMetric(metricNames.http_response_size_bytes) || new Prometheus.Histogram({
             name: metricNames.http_response_size_bytes,
             help: 'Size of HTTP response in bytes',
             labelNames: metricLabels,
-            buckets: responseSizeBuckets || defaultSizeBytesBuckets // buckets for response size from 5 bytes to 10000 bytes
+            buckets: responseSizeBuckets || defaultSizeBytesBuckets
         });
 
         return frameworkMiddleware(framework);

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function getMetricNames(metricNames, useUniqueHistogramName, metricsPrefix, projectName) {
+const getMetricNames = (metricNames, useUniqueHistogramName, metricsPrefix, projectName) => {
     const prefix = useUniqueHistogramName === true ? projectName : metricsPrefix;
 
     if (prefix) {
@@ -10,13 +10,31 @@ function getMetricNames(metricNames, useUniqueHistogramName, metricsPrefix, proj
     }
 
     return metricNames;
-}
+};
 
-function shouldLogMetrics(excludeRoutes, route) {
-    return excludeRoutes.every((path) => {
-        return !route.includes(path);
-    });
-}
+const isArray = (input) => Array.isArray(input);
+
+const isFunction = (input) => typeof input === 'function';
+
+const isString = (input) => typeof input === 'string';
+
+const shouldLogMetrics = (excludeRoutes, route) => excludeRoutes.every((path) => !route.includes(path));
+
+const validateInput = ({ input, isValidInputFn, defaultValue, errorMessage }) => {
+    if (input) {
+        if (isValidInputFn(input)) {
+            return input;
+        } else {
+            throw new Error(errorMessage);
+        }
+    }
+
+    return defaultValue;
+};
 
 module.exports.getMetricNames = getMetricNames;
+module.exports.isArray = isArray;
+module.exports.isFunction = isFunction;
+module.exports.isString = isString;
 module.exports.shouldLogMetrics = shouldLogMetrics;
+module.exports.validateInput = validateInput;

--- a/src/utils.js
+++ b/src/utils.js
@@ -21,7 +21,7 @@ const isString = (input) => typeof input === 'string';
 const shouldLogMetrics = (excludeRoutes, route) => excludeRoutes.every((path) => !route.includes(path));
 
 const validateInput = ({ input, isValidInputFn, defaultValue, errorMessage }) => {
-    if (input) {
+    if (typeof input !== 'undefined') {
         if (isValidInputFn(input)) {
             return input;
         } else {

--- a/test/unit-test/metric-middleware-koa-test.js
+++ b/test/unit-test/metric-middleware-koa-test.js
@@ -756,7 +756,7 @@ describe('metrics-middleware', () => {
                 ctx = { req: req, res: res, request: req, response: res, _matchedRoute: '/path' };
                 func = middleware({
                     metricAdditionalLabels: ['label1', 'label2'],
-                    getMetricsAdditionalLabelValues: () => ({ label1: 'valueLabel1', label2: 'valueLabel2' })
+                    getMetricAdditionalLabelValues: () => ({ label1: 'valueLabel1', label2: 'valueLabel2' })
                 });
                 endTimerStub = sinon.stub();
                 requestTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);

--- a/test/unit-test/metric-middleware-koa-test.js
+++ b/test/unit-test/metric-middleware-koa-test.js
@@ -715,10 +715,10 @@ describe('metrics-middleware', () => {
                 });
             });
         });
-        describe('when calling the function with metricAdditionalLabels option', () => {
+        describe('when calling the function with additionalLabels option', () => {
             before(() => {
                 middleware({
-                    metricAdditionalLabels: ['label1', 'label2']
+                    additionalLabels: ['label1', 'label2']
                 });
             });
             it('should have http_request_duration_seconds with the right labels', () => {
@@ -734,7 +734,7 @@ describe('metrics-middleware', () => {
                 Prometheus.register.clear();
             });
         });
-        describe('when using the middleware with metricAdditionalLabels options', () => {
+        describe('when using the middleware with additionalLabels options', () => {
             let func, req, res, ctx, next, requestSizeObserve, requestTimeObserve, endTimerStub;
             before(() => {
                 next = sinon.stub();
@@ -755,8 +755,8 @@ describe('metrics-middleware', () => {
                 res.statusCode = 200;
                 ctx = { req: req, res: res, request: req, response: res, _matchedRoute: '/path' };
                 func = middleware({
-                    metricAdditionalLabels: ['label1', 'label2'],
-                    getMetricAdditionalLabelValues: () => ({ label1: 'valueLabel1', label2: 'valueLabel2' })
+                    additionalLabels: ['label1', 'label2'],
+                    extractAdditionalLabelValuesFn: () => ({ label1: 'valueLabel1', label2: 'valueLabel2' })
                 });
                 endTimerStub = sinon.stub();
                 requestTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);

--- a/test/unit-test/metric-middleware-koa-test.js
+++ b/test/unit-test/metric-middleware-koa-test.js
@@ -154,7 +154,7 @@ describe('metrics-middleware', () => {
             });
         });
         describe('when using the middleware request has body', () => {
-            let func, req, res, ctx, next, requestSizeObserve, responseTimeObserve, endTimerStub;
+            let func, req, res, ctx, next, requestSizeObserve, requestTimeObserve, endTimerStub;
             before(async () => {
                 next = sinon.stub();
                 req = httpMocks.createRequest({
@@ -175,7 +175,7 @@ describe('metrics-middleware', () => {
                 ctx = { req: req, res: res, request: req, response: res, _matchedRoute: '/path' };
                 func = await middleware();
                 endTimerStub = sinon.stub();
-                responseTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
+                requestTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
                 func(ctx, next);
             });
             it('should save the request size and start time on the request', () => {
@@ -195,19 +195,18 @@ describe('metrics-middleware', () => {
                         route: '/path',
                         code: 200
                     }, 25);
-                    sinon.assert.calledWith(responseTimeObserve, {
-                        method: 'GET'
-                    });
+                    sinon.assert.called(requestTimeObserve);
                     sinon.assert.calledWith(endTimerStub, {
+                        method: 'GET',
                         route: '/path',
                         code: 200
                     });
-                    sinon.assert.calledOnce(responseTimeObserve);
+                    sinon.assert.calledOnce(requestTimeObserve);
                     sinon.assert.calledOnce(endTimerStub);
                 });
                 after(() => {
                     requestSizeObserve.restore();
-                    responseTimeObserve.restore();
+                    requestTimeObserve.restore();
                 });
             });
             after(() => {
@@ -215,7 +214,7 @@ describe('metrics-middleware', () => {
             });
         });
         describe('when using the middleware request does\'t have body', () => {
-            let func, req, res, ctx, next, responseTimeObserve, requestSizeObserve, endTimerStub;
+            let func, req, res, ctx, next, requestTimeObserve, requestSizeObserve, endTimerStub;
             before(async () => {
                 next = sinon.stub();
                 req = httpMocks.createRequest({
@@ -230,7 +229,7 @@ describe('metrics-middleware', () => {
                 ctx = { req: req, res: res, request: req, response: res, _matchedRoute: '/path/:id' };
                 func = await middleware();
                 endTimerStub = sinon.stub();
-                responseTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
+                requestTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
                 func(ctx, next);
             });
             it('should save the request size and start time on the request', () => {
@@ -250,19 +249,18 @@ describe('metrics-middleware', () => {
                         route: '/path/:id',
                         code: 200
                     }, 0);
-                    sinon.assert.calledWith(responseTimeObserve, {
-                        method: 'GET'
-                    });
+                    sinon.assert.called(requestTimeObserve);
                     sinon.assert.calledWith(endTimerStub, {
+                        method: 'GET',
                         route: '/path/:id',
                         code: 200
                     });
                     sinon.assert.calledOnce(endTimerStub);
-                    sinon.assert.calledOnce(responseTimeObserve);
+                    sinon.assert.calledOnce(requestTimeObserve);
                 });
                 after(() => {
                     requestSizeObserve.restore();
-                    responseTimeObserve.restore();
+                    requestTimeObserve.restore();
                 });
             });
             after(() => {
@@ -270,7 +268,7 @@ describe('metrics-middleware', () => {
             });
         });
         describe('when using the middleware response has body', () => {
-            let func, req, res, ctx, next, responseSizeObserve, responseTimeObserve, endTimerStub;
+            let func, req, res, ctx, next, responseSizeObserve, requestTimeObserve, endTimerStub;
             before(async () => {
                 next = sinon.stub();
                 req = httpMocks.createRequest({
@@ -289,7 +287,7 @@ describe('metrics-middleware', () => {
                 func = await middleware();
                 responseSizeObserve = sinon.spy(Prometheus.register.getSingleMetric('http_response_size_bytes'), 'observe');
                 endTimerStub = sinon.stub();
-                responseTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
+                requestTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
                 func(ctx, next);
                 res.emit('finish');
             });
@@ -299,24 +297,23 @@ describe('metrics-middleware', () => {
                     route: '/path',
                     code: 200
                 }, 25);
-                sinon.assert.calledWith(responseTimeObserve, {
-                    method: 'GET'
-                });
+                sinon.assert.called(requestTimeObserve);
                 sinon.assert.calledWith(endTimerStub, {
+                    method: 'GET',
                     route: '/path',
                     code: 200
                 });
-                sinon.assert.calledOnce(responseTimeObserve);
+                sinon.assert.calledOnce(requestTimeObserve);
                 sinon.assert.calledOnce(endTimerStub);
             });
             after(() => {
                 responseSizeObserve.restore();
-                responseTimeObserve.restore();
+                requestTimeObserve.restore();
                 Prometheus.register.clear();
             });
         });
         describe('when using the middleware response does\'t have body', () => {
-            let func, req, res, ctx, next, responseSizeObserve, responseTimeObserve, endTimerStub;
+            let func, req, res, ctx, next, responseSizeObserve, requestTimeObserve, endTimerStub;
             before(async () => {
                 next = sinon.stub();
                 req = httpMocks.createRequest({
@@ -332,7 +329,7 @@ describe('metrics-middleware', () => {
                 func = await middleware();
                 endTimerStub = sinon.stub();
                 responseSizeObserve = sinon.spy(Prometheus.register.getSingleMetric('http_response_size_bytes'), 'observe');
-                responseTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
+                requestTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
                 func(ctx, next);
                 res.emit('finish');
             });
@@ -342,19 +339,18 @@ describe('metrics-middleware', () => {
                     route: '/path',
                     code: 200
                 }, 0);
-                sinon.assert.calledWith(responseTimeObserve, {
-                    method: 'GET'
-                });
+                sinon.assert.called(requestTimeObserve);
                 sinon.assert.calledWith(endTimerStub, {
+                    method: 'GET',
                     route: '/path',
                     code: 200
                 });
-                sinon.assert.calledOnce(responseTimeObserve);
+                sinon.assert.calledOnce(requestTimeObserve);
                 sinon.assert.calledOnce(endTimerStub);
             });
             after(() => {
                 responseSizeObserve.restore();
-                responseTimeObserve.restore();
+                requestTimeObserve.restore();
                 Prometheus.register.clear();
             });
         });
@@ -408,7 +404,7 @@ describe('metrics-middleware', () => {
             });
         });
         describe('when using middleware request baseUrl is undefined', () => {
-            let func, req, res, ctx, next, requestSizeObserve, responseTimeObserve, endTimerStub;
+            let func, req, res, ctx, next, requestSizeObserve, requestTimeObserve, endTimerStub;
             before(async () => {
                 next = sinon.stub();
                 req = httpMocks.createRequest({
@@ -430,7 +426,7 @@ describe('metrics-middleware', () => {
                 ctx = { req: req, res: res, request: req, response: res, _matchedRoute: '/path' };
                 func = await middleware();
                 endTimerStub = sinon.stub();
-                responseTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
+                requestTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
                 func(ctx, next);
                 requestSizeObserve = sinon.spy(Prometheus.register.getSingleMetric('http_request_size_bytes'), 'observe');
                 res.emit('finish');
@@ -441,24 +437,23 @@ describe('metrics-middleware', () => {
                     route: '/path',
                     code: 200
                 }, 25);
-                sinon.assert.calledWith(responseTimeObserve, {
-                    method: 'GET'
-                });
+                sinon.assert.called(requestTimeObserve);
                 sinon.assert.calledWith(endTimerStub, {
+                    method: 'GET',
                     route: '/path',
                     code: 200
                 });
-                sinon.assert.calledOnce(responseTimeObserve);
+                sinon.assert.calledOnce(requestTimeObserve);
                 sinon.assert.calledOnce(endTimerStub);
             });
             after(() => {
                 requestSizeObserve.restore();
-                responseTimeObserve.restore();
+                requestTimeObserve.restore();
                 Prometheus.register.clear();
             });
         });
         describe('when using middleware request baseUrl is undefined and path is not "/"', () => {
-            let func, req, res, ctx, next, requestSizeObserve, responseTimeObserve, endTimerStub;
+            let func, req, res, ctx, next, requestSizeObserve, requestTimeObserve, endTimerStub;
             before(async () => {
                 next = sinon.stub();
                 req = httpMocks.createRequest({
@@ -480,7 +475,7 @@ describe('metrics-middleware', () => {
                 ctx = { req: req, res: res, request: req, response: res, _matchedRoute: '/path/:id' };
                 func = await middleware();
                 endTimerStub = sinon.stub();
-                responseTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
+                requestTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
                 func(ctx, next);
                 requestSizeObserve = sinon.spy(Prometheus.register.getSingleMetric('http_request_size_bytes'), 'observe');
                 res.emit('finish');
@@ -491,24 +486,23 @@ describe('metrics-middleware', () => {
                     route: '/path/:id',
                     code: 200
                 }, 25);
-                sinon.assert.calledWith(responseTimeObserve, {
-                    method: 'GET'
-                });
+                sinon.assert.called(requestTimeObserve);
                 sinon.assert.calledWith(endTimerStub, {
+                    method: 'GET',
                     route: '/path/:id',
                     code: 200
                 });
-                sinon.assert.calledOnce(responseTimeObserve);
+                sinon.assert.calledOnce(requestTimeObserve);
                 sinon.assert.calledOnce(endTimerStub);
             });
             after(() => {
                 requestSizeObserve.restore();
-                responseTimeObserve.restore();
+                requestTimeObserve.restore();
                 Prometheus.register.clear();
             });
         });
         describe('when using middleware request and route is with sub routing', () => {
-            let match, func, req, res, ctx, next, requestSizeObserve, responseTimeObserve, endTimerStub;
+            let match, func, req, res, ctx, next, requestSizeObserve, requestTimeObserve, endTimerStub;
             before(async () => {
                 match = sinon.stub().returns({ path: [{ path: '/path/:id' }] });
                 next = sinon.stub();
@@ -531,7 +525,7 @@ describe('metrics-middleware', () => {
                 ctx = { req: req, res: res, request: req, response: res, router: { match: match }, _matchedRoute: '/v1(.*)', originalUrl: '/v1/path/123' };
                 func = await middleware();
                 endTimerStub = sinon.stub();
-                responseTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
+                requestTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
                 func(ctx, next);
                 requestSizeObserve = sinon.spy(Prometheus.register.getSingleMetric('http_request_size_bytes'), 'observe');
                 res.emit('finish');
@@ -542,24 +536,23 @@ describe('metrics-middleware', () => {
                     route: '/v1/path/:id',
                     code: 200
                 }, 25);
-                sinon.assert.calledWith(responseTimeObserve, {
-                    method: 'GET'
-                });
+                sinon.assert.called(requestTimeObserve);
                 sinon.assert.calledWith(endTimerStub, {
+                    method: 'GET',
                     route: '/v1/path/:id',
                     code: 200
                 });
-                sinon.assert.calledOnce(responseTimeObserve);
+                sinon.assert.calledOnce(requestTimeObserve);
                 sinon.assert.calledOnce(endTimerStub);
             });
             after(() => {
                 requestSizeObserve.restore();
-                responseTimeObserve.restore();
+                requestTimeObserve.restore();
                 Prometheus.register.clear();
             });
         });
         describe('when using middleware request and route is with sub routing, first path is with place holder', () => {
-            let match, func, req, res, ctx, next, requestSizeObserve, responseTimeObserve, endTimerStub;
+            let match, func, req, res, ctx, next, requestSizeObserve, requestTimeObserve, endTimerStub;
             before(async () => {
                 match = sinon.stub().returns({ path: [{ path: '/v1(.*)' }, { path: '/path/:id' }] });
                 next = sinon.stub();
@@ -582,7 +575,7 @@ describe('metrics-middleware', () => {
                 ctx = { req: req, res: res, request: req, response: res, router: { match: match }, _matchedRoute: '/v1(.*)', originalUrl: '/v1/path/123' };
                 func = await middleware();
                 endTimerStub = sinon.stub();
-                responseTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
+                requestTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
                 func(ctx, next);
                 requestSizeObserve = sinon.spy(Prometheus.register.getSingleMetric('http_request_size_bytes'), 'observe');
                 res.emit('finish');
@@ -593,24 +586,23 @@ describe('metrics-middleware', () => {
                     route: '/v1/path/:id',
                     code: 200
                 }, 25);
-                sinon.assert.calledWith(responseTimeObserve, {
-                    method: 'GET'
-                });
+                sinon.assert.called(requestTimeObserve);
                 sinon.assert.calledWith(endTimerStub, {
+                    method: 'GET',
                     route: '/v1/path/:id',
                     code: 200
                 });
-                sinon.assert.calledOnce(responseTimeObserve);
+                sinon.assert.calledOnce(requestTimeObserve);
                 sinon.assert.calledOnce(endTimerStub);
             });
             after(() => {
                 requestSizeObserve.restore();
-                responseTimeObserve.restore();
+                requestTimeObserve.restore();
                 Prometheus.register.clear();
             });
         });
         describe('when using middleware request and route is with sub routing, regex of path with base path', () => {
-            let match, func, req, res, ctx, next, requestSizeObserve, responseTimeObserve, endTimerStub;
+            let match, func, req, res, ctx, next, requestSizeObserve, requestTimeObserve, endTimerStub;
             before(async () => {
                 match = sinon.stub();
                 match.onFirstCall().returns({ path: [] });
@@ -635,7 +627,7 @@ describe('metrics-middleware', () => {
                 ctx = { req: req, res: res, request: req, response: res, router: { match: match }, _matchedRoute: '/v1(.*)', originalUrl: '/v1/path/123' };
                 func = await middleware();
                 endTimerStub = sinon.stub();
-                responseTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
+                requestTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
                 func(ctx, next);
                 requestSizeObserve = sinon.spy(Prometheus.register.getSingleMetric('http_request_size_bytes'), 'observe');
                 res.emit('finish');
@@ -646,19 +638,18 @@ describe('metrics-middleware', () => {
                     route: '/v1/path/:id',
                     code: 200
                 }, 25);
-                sinon.assert.calledWith(responseTimeObserve, {
-                    method: 'GET'
-                });
+                sinon.assert.called(requestTimeObserve);
                 sinon.assert.calledWith(endTimerStub, {
+                    method: 'GET',
                     route: '/v1/path/:id',
                     code: 200
                 });
-                sinon.assert.calledOnce(responseTimeObserve);
+                sinon.assert.calledOnce(requestTimeObserve);
                 sinon.assert.calledOnce(endTimerStub);
             });
             after(() => {
                 requestSizeObserve.restore();
-                responseTimeObserve.restore();
+                requestTimeObserve.restore();
                 Prometheus.register.clear();
             });
         });
@@ -722,6 +713,79 @@ describe('metrics-middleware', () => {
                         }, 510);
                     });
                 });
+            });
+        });
+        describe('when calling the function with metricAdditionalLabels option', () => {
+            before(() => {
+                middleware({
+                    metricAdditionalLabels: ['label1', 'label2']
+                });
+            });
+            it('should have http_request_duration_seconds with the right labels', () => {
+                expect(Prometheus.register.getSingleMetric('http_request_duration_seconds').labelNames).to.have.members(['method', 'route', 'code', 'label1', 'label2']);
+            });
+            it('should have http_request_size_bytes with the right labels', () => {
+                expect(Prometheus.register.getSingleMetric('http_request_size_bytes').labelNames).to.have.members(['method', 'route', 'code', 'label1', 'label2']);
+            });
+            it('should have http_response_size_bytes with the right labels', () => {
+                expect(Prometheus.register.getSingleMetric('http_response_size_bytes').labelNames).to.have.members(['method', 'route', 'code', 'label1', 'label2']);
+            });
+            after(() => {
+                Prometheus.register.clear();
+            });
+        });
+        describe('when using the middleware with metricAdditionalLabels options', () => {
+            let func, req, res, ctx, next, requestSizeObserve, requestTimeObserve, endTimerStub;
+            before(() => {
+                next = sinon.stub();
+                req = httpMocks.createRequest({
+                    url: '/path',
+                    method: 'GET',
+                    body: {
+                        foo: 'bar'
+                    },
+                    headers: {
+                        'content-length': '25'
+                    }
+                });
+                req.socket = {};
+                res = httpMocks.createResponse({
+                    eventEmitter: EventEmitter
+                });
+                res.statusCode = 200;
+                ctx = { req: req, res: res, request: req, response: res, _matchedRoute: '/path' };
+                func = middleware({
+                    metricAdditionalLabels: ['label1', 'label2'],
+                    getMetricsAdditionalLabelValues: () => ({ label1: 'valueLabel1', label2: 'valueLabel2' })
+                });
+                endTimerStub = sinon.stub();
+                requestTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
+                func(ctx, next);
+                requestSizeObserve = sinon.spy(Prometheus.register.getSingleMetric('http_request_size_bytes'), 'observe');
+                res.emit('finish');
+            });
+            it('metrics should include additional metrics', () => {
+                sinon.assert.calledWithExactly(requestSizeObserve, {
+                    label1: 'valueLabel1',
+                    label2: 'valueLabel2',
+                    method: 'GET',
+                    route: '/path',
+                    code: 200
+                }, 25);
+                sinon.assert.called(requestTimeObserve);
+                sinon.assert.calledWith(endTimerStub, {
+                    label1: 'valueLabel1',
+                    label2: 'valueLabel2',
+                    method: 'GET',
+                    route: '/path',
+                    code: 200
+                });
+                sinon.assert.calledOnce(endTimerStub);
+            });
+            after(() => {
+                requestSizeObserve.restore();
+                requestTimeObserve.restore();
+                Prometheus.register.clear();
             });
         });
     });

--- a/test/unit-test/metric-middleware-koa-test.js
+++ b/test/unit-test/metric-middleware-koa-test.js
@@ -407,7 +407,7 @@ describe('metrics-middleware', () => {
                 Prometheus.register.clear();
             });
         });
-        describe('when using middleware request baseUrl is undefined', function () {
+        describe('when using middleware request baseUrl is undefined', () => {
             let func, req, res, ctx, next, requestSizeObserve, responseTimeObserve, endTimerStub;
             before(async () => {
                 next = sinon.stub();
@@ -457,7 +457,7 @@ describe('metrics-middleware', () => {
                 Prometheus.register.clear();
             });
         });
-        describe('when using middleware request baseUrl is undefined and path is not "/"', function () {
+        describe('when using middleware request baseUrl is undefined and path is not "/"', () => {
             let func, req, res, ctx, next, requestSizeObserve, responseTimeObserve, endTimerStub;
             before(async () => {
                 next = sinon.stub();
@@ -507,7 +507,7 @@ describe('metrics-middleware', () => {
                 Prometheus.register.clear();
             });
         });
-        describe('when using middleware request and route is with sub routing', function () {
+        describe('when using middleware request and route is with sub routing', () => {
             let match, func, req, res, ctx, next, requestSizeObserve, responseTimeObserve, endTimerStub;
             before(async () => {
                 match = sinon.stub().returns({ path: [{ path: '/path/:id' }] });
@@ -558,7 +558,7 @@ describe('metrics-middleware', () => {
                 Prometheus.register.clear();
             });
         });
-        describe('when using middleware request and route is with sub routing, first path is with place holder', function () {
+        describe('when using middleware request and route is with sub routing, first path is with place holder', () => {
             let match, func, req, res, ctx, next, requestSizeObserve, responseTimeObserve, endTimerStub;
             before(async () => {
                 match = sinon.stub().returns({ path: [{ path: '/v1(.*)' }, { path: '/path/:id' }] });
@@ -609,7 +609,7 @@ describe('metrics-middleware', () => {
                 Prometheus.register.clear();
             });
         });
-        describe('when using middleware request and route is with sub routing, regex of path with base path', function () {
+        describe('when using middleware request and route is with sub routing, regex of path with base path', () => {
             let match, func, req, res, ctx, next, requestSizeObserve, responseTimeObserve, endTimerStub;
             before(async () => {
                 match = sinon.stub();
@@ -662,43 +662,43 @@ describe('metrics-middleware', () => {
                 Prometheus.register.clear();
             });
         });
-        describe('when _getConnections called', function () {
-            let Middleware, server, numberOfConnectionsGauge, koaMiddleware, promethusStub;
-            before(function () {
+        describe('when _getConnections called', () => {
+            let Middleware, server, numberOfConnectionsGauge, koaMiddleware, prometheusStub;
+            before(() => {
                 Middleware = require('../../src/koa-middleware');
                 server = {
                     getConnections: sinon.stub()
                 };
             });
-            describe('when there is no server', function () {
-                before(function () {
+            describe('when there is no server', () => {
+                before(() => {
                     const koaMiddleware = new Middleware({});
                     koaMiddleware._getConnections();
                 });
-                it('should not call getConnections', function () {
+                it('should not call getConnections', () => {
                     sinon.assert.notCalled(server.getConnections);
                 });
             });
-            describe('when there is server', function () {
-                after(function () {
-                    promethusStub.restore();
+            describe('when there is server', () => {
+                after(() => {
+                    prometheusStub.restore();
                 });
-                afterEach(function () {
+                afterEach(() => {
                     numberOfConnectionsGauge.set.resetHistory();
                 });
-                before(function () {
+                before(() => {
                     numberOfConnectionsGauge = {
                         set: sinon.stub()
                     };
-                    promethusStub = sinon.stub(Prometheus.register, 'getSingleMetric').returns(numberOfConnectionsGauge);
+                    prometheusStub = sinon.stub(Prometheus.register, 'getSingleMetric').returns(numberOfConnectionsGauge);
                 });
-                describe('when getConnections return count', function () {
-                    before(function () {
+                describe('when getConnections return count', () => {
+                    before(() => {
                         server.getConnections = sinon.stub().yields(null, 1);
                         koaMiddleware = new Middleware({ server: server, numberOfConnectionsGauge: numberOfConnectionsGauge });
                         koaMiddleware._collectDefaultServerMetrics(1000);
                     });
-                    it('should call numberOfConnectionsGauge.set with count', function (done) {
+                    it('should call numberOfConnectionsGauge.set with count', (done) => {
                         setTimeout(() => {
                             sinon.assert.calledOnce(server.getConnections);
                             sinon.assert.calledOnce(numberOfConnectionsGauge.set);
@@ -707,14 +707,14 @@ describe('metrics-middleware', () => {
                         }, 1100);
                     });
                 });
-                describe('when getConnections return count', function () {
-                    before(function () {
+                describe('when getConnections return count', () => {
+                    before(() => {
                         server.getConnections = sinon.stub().reset();
                         server.getConnections = sinon.stub().yields(new Error('error'));
                         koaMiddleware = new Middleware({ server: server, numberOfConnectionsGauge: numberOfConnectionsGauge });
                         koaMiddleware._collectDefaultServerMetrics(500);
                     });
-                    it('should not call numberOfConnectionsGauge.set with count', function (done) {
+                    it('should not call numberOfConnectionsGauge.set with count', (done) => {
                         setTimeout(() => {
                             sinon.assert.calledOnce(server.getConnections);
                             sinon.assert.notCalled(numberOfConnectionsGauge.set);

--- a/test/unit-test/metric-middleware-test.js
+++ b/test/unit-test/metric-middleware-test.js
@@ -577,10 +577,10 @@ describe('metrics-middleware', () => {
             });
         });
     });
-    describe('when calling the function with metricAdditionalLabels option', () => {
+    describe('when calling the function with additionalLabels option', () => {
         before(() => {
             middleware({
-                metricAdditionalLabels: ['label1', 'label2']
+                additionalLabels: ['label1', 'label2']
             });
         });
         it('should have http_request_duration_seconds with the right labels', () => {
@@ -596,7 +596,7 @@ describe('metrics-middleware', () => {
             Prometheus.register.clear();
         });
     });
-    describe('when using the middleware with metricAdditionalLabels options', () => {
+    describe('when using the middleware with additionalLabels options', () => {
         let func, req, res, next, requestSizeObserve, requestTimeObserve, endTimerStub;
         before(() => {
             next = sinon.stub();
@@ -620,8 +620,8 @@ describe('metrics-middleware', () => {
             delete req.baseUrl;
             res.statusCode = 200;
             func = middleware({
-                metricAdditionalLabels: ['label1', 'label2'],
-                getMetricAdditionalLabelValues: () => ({ label1: 'valueLabel1', label2: 'valueLabel2' })
+                additionalLabels: ['label1', 'label2'],
+                extractAdditionalLabelValuesFn: () => ({ label1: 'valueLabel1', label2: 'valueLabel2' })
             });
             endTimerStub = sinon.stub();
             requestTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);

--- a/test/unit-test/metric-middleware-test.js
+++ b/test/unit-test/metric-middleware-test.js
@@ -418,7 +418,7 @@ describe('metrics-middleware', () => {
             Prometheus.register.clear();
         });
     });
-    describe('when using middleware request baseUrl is undefined', function () {
+    describe('when using middleware request baseUrl is undefined', () => {
         let func, req, res, next, requestSizeObserve, responseTimeObserve, endTimerStub;
         before(async () => {
             next = sinon.stub();
@@ -470,7 +470,7 @@ describe('metrics-middleware', () => {
             Prometheus.register.clear();
         });
     });
-    describe('when using middleware request baseUrl is undifined and path is not "/"', function () {
+    describe('when using middleware request baseUrl is undefined and path is not "/"', () => {
         let func, req, res, next, requestSizeObserve, responseTimeObserve, endTimerStub;
         before(async () => {
             next = sinon.stub();
@@ -522,43 +522,43 @@ describe('metrics-middleware', () => {
             Prometheus.register.clear();
         });
     });
-    describe('when _getConnections called', function () {
-        let Middleware, server, numberOfConnectionsGauge, expressMiddleware, promethusStub;
-        before(function () {
+    describe('when _getConnections called', () => {
+        let Middleware, server, numberOfConnectionsGauge, expressMiddleware, prometheusStub;
+        before(() => {
             Middleware = require('../../src/express-middleware');
             server = {
                 getConnections: sinon.stub()
             };
         });
-        describe('when there is no server', function () {
-            before(function () {
+        describe('when there is no server', () => {
+            before(() => {
                 const expressMiddleware = new Middleware({});
                 expressMiddleware._getConnections();
             });
-            it('should not call getConnections', function () {
+            it('should not call getConnections', () => {
                 sinon.assert.notCalled(server.getConnections);
             });
         });
-        describe('when there is server', function () {
-            after(function () {
-                promethusStub.restore();
+        describe('when there is server', () => {
+            after(() => {
+                prometheusStub.restore();
             });
-            afterEach(function () {
+            afterEach(() => {
                 numberOfConnectionsGauge.set.resetHistory();
             });
-            before(function () {
+            before(() => {
                 numberOfConnectionsGauge = {
                     set: sinon.stub()
                 };
-                promethusStub = sinon.stub(Prometheus.register, 'getSingleMetric').returns(numberOfConnectionsGauge);
+                prometheusStub = sinon.stub(Prometheus.register, 'getSingleMetric').returns(numberOfConnectionsGauge);
             });
-            describe('when getConnections return count', function () {
-                before(function () {
+            describe('when getConnections return count', () => {
+                before(() => {
                     server.getConnections = sinon.stub().yields(null, 1);
                     expressMiddleware = new Middleware({ server: server, numberOfConnectionsGauge: numberOfConnectionsGauge });
                     expressMiddleware._collectDefaultServerMetrics(1000);
                 });
-                it('should call numberOfConnectionsGauge.set with count', function (done) {
+                it('should call numberOfConnectionsGauge.set with count', (done) => {
                     setTimeout(() => {
                         sinon.assert.calledOnce(server.getConnections);
                         sinon.assert.calledOnce(numberOfConnectionsGauge.set);
@@ -567,13 +567,13 @@ describe('metrics-middleware', () => {
                     }, 1100);
                 });
             });
-            describe('when getConnections return count', function () {
-                before(function () {
+            describe('when getConnections return count', () => {
+                before(() => {
                     server.getConnections = sinon.stub().yields(new Error('error'));
                     expressMiddleware = new Middleware({ server: server, numberOfConnectionsGauge: numberOfConnectionsGauge });
                     expressMiddleware._collectDefaultServerMetrics(500);
                 });
-                it('should not call numberOfConnectionsGauge.set with count', function (done) {
+                it('should not call numberOfConnectionsGauge.set with count', (done) => {
                     setTimeout(() => {
                         sinon.assert.calledOnce(server.getConnections);
                         sinon.assert.notCalled(numberOfConnectionsGauge.set);

--- a/test/unit-test/metric-middleware-test.js
+++ b/test/unit-test/metric-middleware-test.js
@@ -621,7 +621,7 @@ describe('metrics-middleware', () => {
             res.statusCode = 200;
             func = middleware({
                 metricAdditionalLabels: ['label1', 'label2'],
-                getMetricsAdditionalLabelValues: () => ({ label1: 'valueLabel1', label2: 'valueLabel2' })
+                getMetricAdditionalLabelValues: () => ({ label1: 'valueLabel1', label2: 'valueLabel2' })
             });
             endTimerStub = sinon.stub();
             requestTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);

--- a/test/unit-test/metric-middleware-test.js
+++ b/test/unit-test/metric-middleware-test.js
@@ -153,7 +153,7 @@ describe('metrics-middleware', () => {
         });
     });
     describe('when using the middleware request has body', () => {
-        let func, req, res, next, requestSizeObserve, responseTimeObserve, endTimerStub;
+        let func, req, res, next, requestSizeObserve, requestTimeObserve, endTimerStub;
         before(async () => {
             next = sinon.stub();
             req = httpMocks.createRequest({
@@ -176,7 +176,7 @@ describe('metrics-middleware', () => {
             res.statusCode = 200;
             func = await middleware();
             endTimerStub = sinon.stub();
-            responseTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
+            requestTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
             func(req, res, next);
         });
         it('should save the request size and start time on the request', () => {
@@ -196,19 +196,18 @@ describe('metrics-middleware', () => {
                     route: '/path',
                     code: 200
                 }, 25);
-                sinon.assert.calledWith(responseTimeObserve, {
-                    method: 'GET'
-                });
+                sinon.assert.called(requestTimeObserve);
                 sinon.assert.calledWith(endTimerStub, {
+                    method: 'GET',
                     route: '/path',
                     code: 200
                 });
-                sinon.assert.calledOnce(responseTimeObserve);
+                sinon.assert.calledOnce(requestTimeObserve);
                 sinon.assert.calledOnce(endTimerStub);
             });
             after(() => {
                 requestSizeObserve.restore();
-                responseTimeObserve.restore();
+                requestTimeObserve.restore();
             });
         });
         after(() => {
@@ -216,7 +215,7 @@ describe('metrics-middleware', () => {
         });
     });
     describe('when using the middleware request has\'t body', () => {
-        let func, req, res, next, responseTimeObserve, requestSizeObserve, endTimerStub;
+        let func, req, res, next, requestTimeObserve, requestSizeObserve, endTimerStub;
         before(async () => {
             next = sinon.stub();
             req = httpMocks.createRequest({
@@ -233,7 +232,7 @@ describe('metrics-middleware', () => {
             res.statusCode = 200;
             func = await middleware();
             endTimerStub = sinon.stub();
-            responseTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
+            requestTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
             func(req, res, next);
         });
         it('should save the request size and start time on the request', () => {
@@ -253,19 +252,18 @@ describe('metrics-middleware', () => {
                     route: '/path/:id',
                     code: 200
                 }, 0);
-                sinon.assert.calledWith(responseTimeObserve, {
-                    method: 'GET'
-                });
+                sinon.assert.called(requestTimeObserve);
                 sinon.assert.calledWith(endTimerStub, {
+                    method: 'GET',
                     route: '/path/:id',
                     code: 200
                 });
                 sinon.assert.calledOnce(endTimerStub);
-                sinon.assert.calledOnce(responseTimeObserve);
+                sinon.assert.calledOnce(requestTimeObserve);
             });
             after(() => {
                 requestSizeObserve.restore();
-                responseTimeObserve.restore();
+                requestTimeObserve.restore();
             });
         });
         after(() => {
@@ -273,7 +271,7 @@ describe('metrics-middleware', () => {
         });
     });
     describe('when using the middleware response has body', () => {
-        let func, req, res, next, responseSizeObserve, responseTimeObserve, endTimerStub;
+        let func, req, res, next, responseSizeObserve, requestTimeObserve, endTimerStub;
         before(async () => {
             next = sinon.stub();
             req = httpMocks.createRequest({
@@ -294,7 +292,7 @@ describe('metrics-middleware', () => {
             func = await middleware();
             responseSizeObserve = sinon.spy(Prometheus.register.getSingleMetric('http_response_size_bytes'), 'observe');
             endTimerStub = sinon.stub();
-            responseTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
+            requestTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
             func(req, res, next);
             res.emit('finish');
         });
@@ -304,24 +302,23 @@ describe('metrics-middleware', () => {
                 route: '/path',
                 code: 200
             }, 25);
-            sinon.assert.calledWith(responseTimeObserve, {
-                method: 'GET'
-            });
+            sinon.assert.called(requestTimeObserve);
             sinon.assert.calledWith(endTimerStub, {
+                method: 'GET',
                 route: '/path',
                 code: 200
             });
-            sinon.assert.calledOnce(responseTimeObserve);
+            sinon.assert.calledOnce(requestTimeObserve);
             sinon.assert.calledOnce(endTimerStub);
         });
         after(() => {
             responseSizeObserve.restore();
-            responseTimeObserve.restore();
+            requestTimeObserve.restore();
             Prometheus.register.clear();
         });
     });
     describe('when using the middleware response has\'t body', () => {
-        let func, req, res, next, responseSizeObserve, responseTimeObserve, endTimerStub;
+        let func, req, res, next, responseSizeObserve, requestTimeObserve, endTimerStub;
         before(async () => {
             next = sinon.stub();
             req = httpMocks.createRequest({
@@ -339,7 +336,7 @@ describe('metrics-middleware', () => {
             func = await middleware();
             endTimerStub = sinon.stub();
             responseSizeObserve = sinon.spy(Prometheus.register.getSingleMetric('http_response_size_bytes'), 'observe');
-            responseTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
+            requestTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
             func(req, res, next);
             res.emit('finish');
         });
@@ -349,19 +346,18 @@ describe('metrics-middleware', () => {
                 route: '/path',
                 code: 200
             }, 0);
-            sinon.assert.calledWith(responseTimeObserve, {
-                method: 'GET'
-            });
+            sinon.assert.called(requestTimeObserve);
             sinon.assert.calledWith(endTimerStub, {
+                method: 'GET',
                 route: '/path',
                 code: 200
             });
-            sinon.assert.calledOnce(responseTimeObserve);
+            sinon.assert.calledOnce(requestTimeObserve);
             sinon.assert.calledOnce(endTimerStub);
         });
         after(() => {
             responseSizeObserve.restore();
-            responseTimeObserve.restore();
+            requestTimeObserve.restore();
             Prometheus.register.clear();
         });
     });
@@ -419,7 +415,7 @@ describe('metrics-middleware', () => {
         });
     });
     describe('when using middleware request baseUrl is undefined', () => {
-        let func, req, res, next, requestSizeObserve, responseTimeObserve, endTimerStub;
+        let func, req, res, next, requestSizeObserve, requestTimeObserve, endTimerStub;
         before(async () => {
             next = sinon.stub();
             req = httpMocks.createRequest({
@@ -443,7 +439,7 @@ describe('metrics-middleware', () => {
             res.statusCode = 200;
             func = await middleware();
             endTimerStub = sinon.stub();
-            responseTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
+            requestTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
             func(req, res, next);
             requestSizeObserve = sinon.spy(Prometheus.register.getSingleMetric('http_request_size_bytes'), 'observe');
             res.emit('finish');
@@ -454,24 +450,23 @@ describe('metrics-middleware', () => {
                 route: '/path',
                 code: 200
             }, 25);
-            sinon.assert.calledWith(responseTimeObserve, {
-                method: 'GET'
-            });
+            sinon.assert.called(requestTimeObserve);
             sinon.assert.calledWith(endTimerStub, {
+                method: 'GET',
                 route: '/path',
                 code: 200
             });
-            sinon.assert.calledOnce(responseTimeObserve);
+            sinon.assert.calledOnce(requestTimeObserve);
             sinon.assert.calledOnce(endTimerStub);
         });
         after(() => {
             requestSizeObserve.restore();
-            responseTimeObserve.restore();
+            requestTimeObserve.restore();
             Prometheus.register.clear();
         });
     });
     describe('when using middleware request baseUrl is undefined and path is not "/"', () => {
-        let func, req, res, next, requestSizeObserve, responseTimeObserve, endTimerStub;
+        let func, req, res, next, requestSizeObserve, requestTimeObserve, endTimerStub;
         before(async () => {
             next = sinon.stub();
             req = httpMocks.createRequest({
@@ -495,7 +490,7 @@ describe('metrics-middleware', () => {
             res.statusCode = 200;
             func = await middleware();
             endTimerStub = sinon.stub();
-            responseTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
+            requestTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
             func(req, res, next);
             requestSizeObserve = sinon.spy(Prometheus.register.getSingleMetric('http_request_size_bytes'), 'observe');
             res.emit('finish');
@@ -506,19 +501,18 @@ describe('metrics-middleware', () => {
                 route: '/path/:id',
                 code: 200
             }, 25);
-            sinon.assert.calledWith(responseTimeObserve, {
-                method: 'GET'
-            });
+            sinon.assert.called(requestTimeObserve);
             sinon.assert.calledWith(endTimerStub, {
+                method: 'GET',
                 route: '/path/:id',
                 code: 200
             });
-            sinon.assert.calledOnce(responseTimeObserve);
+            sinon.assert.calledOnce(requestTimeObserve);
             sinon.assert.calledOnce(endTimerStub);
         });
         after(() => {
             requestSizeObserve.restore();
-            responseTimeObserve.restore();
+            requestTimeObserve.restore();
             Prometheus.register.clear();
         });
     });
@@ -581,6 +575,83 @@ describe('metrics-middleware', () => {
                     }, 510);
                 });
             });
+        });
+    });
+    describe('when calling the function with metricAdditionalLabels option', () => {
+        before(() => {
+            middleware({
+                metricAdditionalLabels: ['label1', 'label2']
+            });
+        });
+        it('should have http_request_duration_seconds with the right labels', () => {
+            expect(Prometheus.register.getSingleMetric('http_request_duration_seconds').labelNames).to.have.members(['method', 'route', 'code', 'label1', 'label2']);
+        });
+        it('should have http_request_size_bytes with the right labels', () => {
+            expect(Prometheus.register.getSingleMetric('http_request_size_bytes').labelNames).to.have.members(['method', 'route', 'code', 'label1', 'label2']);
+        });
+        it('should have http_response_size_bytes with the right labels', () => {
+            expect(Prometheus.register.getSingleMetric('http_response_size_bytes').labelNames).to.have.members(['method', 'route', 'code', 'label1', 'label2']);
+        });
+        after(() => {
+            Prometheus.register.clear();
+        });
+    });
+    describe('when using the middleware with metricAdditionalLabels options', () => {
+        let func, req, res, next, requestSizeObserve, requestTimeObserve, endTimerStub;
+        before(() => {
+            next = sinon.stub();
+            req = httpMocks.createRequest({
+                url: '/path/:id',
+                method: 'GET',
+                body: {
+                    foo: 'bar'
+                },
+                headers: {
+                    'content-length': '25'
+                }
+            });
+            req.socket = {};
+            req.route = {
+                path: '/:id'
+            };
+            res = httpMocks.createResponse({
+                eventEmitter: EventEmitter
+            });
+            delete req.baseUrl;
+            res.statusCode = 200;
+            func = middleware({
+                metricAdditionalLabels: ['label1', 'label2'],
+                getMetricsAdditionalLabelValues: () => ({ label1: 'valueLabel1', label2: 'valueLabel2' })
+            });
+            endTimerStub = sinon.stub();
+            requestTimeObserve = sinon.stub(Prometheus.register.getSingleMetric('http_request_duration_seconds'), 'startTimer').returns(endTimerStub);
+            func(req, res, next);
+            requestSizeObserve = sinon.spy(Prometheus.register.getSingleMetric('http_request_size_bytes'), 'observe');
+            res.emit('finish');
+        });
+        it('metrics should include additional metrics', () => {
+            sinon.assert.calledWithExactly(requestSizeObserve, {
+                label1: 'valueLabel1',
+                label2: 'valueLabel2',
+                method: 'GET',
+                route: '/path/:id',
+                code: 200
+            }, 25);
+            sinon.assert.called(requestTimeObserve);
+            sinon.assert.calledWith(endTimerStub, {
+                label1: 'valueLabel1',
+                label2: 'valueLabel2',
+                method: 'GET',
+                route: '/path/:id',
+                code: 200
+            });
+            sinon.assert.calledOnce(requestTimeObserve);
+            sinon.assert.calledOnce(endTimerStub);
+        });
+        after(() => {
+            requestSizeObserve.restore();
+            requestTimeObserve.restore();
+            Prometheus.register.clear();
         });
     });
 });

--- a/test/unit-test/request-response-collector-test.js
+++ b/test/unit-test/request-response-collector-test.js
@@ -405,7 +405,7 @@ describe('request.js response time collector', () => {
             });
         });
     });
-    describe('initizalized with useUniqueHistogramName = true', () => {
+    describe('initialized with useUniqueHistogramName = true', () => {
         before(() => {
             Collector.init({ useUniqueHistogramName: true });
         });
@@ -433,7 +433,7 @@ describe('request.js response time collector', () => {
             });
         });
     });
-    describe('initizalized with prefix name', () => {
+    describe('initialized with prefix name', () => {
         before(() => {
             Collector.init({ prefix: 'prefix' });
         });
@@ -461,7 +461,7 @@ describe('request.js response time collector', () => {
             });
         });
     });
-    describe('initizalized with customized durationBuckets', () => {
+    describe('initialized with customized durationBuckets', () => {
         before(() => {
             Collector.init({ durationBuckets: [0.002, 0.01, 0.025, 0.035, 0.055, 0.15, 0.155, 0.35, 0.55] });
         });
@@ -491,7 +491,7 @@ describe('request.js response time collector', () => {
             });
         });
     });
-    describe('initizalized with both useUniqueHistogramName = true and prefix', () => {
+    describe('initialized with both useUniqueHistogramName = true and prefix', () => {
         before(() => {
             Collector.init({ useUniqueHistogramName: true, prefix: 'prefix' });
         });
@@ -509,9 +509,9 @@ describe('request.js response time collector', () => {
             });
         });
     });
-    describe('use claas format', function () {
+    describe('use claas format', () => {
         let collectorInstance;
-        before(function () {
+        before(() => {
             collectorInstance = new Collector();
         });
         afterEach(() => {

--- a/test/unit-test/utils-test.js
+++ b/test/unit-test/utils-test.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const expect = require('chai').expect;
+const utils = require('../../src/utils');
+
+describe('utils', () => {
+    describe('getMetricNames', () => {
+        it('', () => {
+            const metricNames = ['metric1'];
+            const useUniqueHistogramName = true;
+            const metricsPrefix = true;
+            const projectName = 'mock_project';
+            expect(utils.getMetricNames(metricNames, useUniqueHistogramName, metricsPrefix, projectName)[0]).to.equal('mock_project_metric1');
+        });
+    });
+    describe('isArray', () => {
+        it('should return true when it\'s an array', () => {
+            expect(utils.isArray([])).to.equal(true);
+        });
+        it('should return false when it\'s not an array', () => {
+            expect(utils.isArray(null)).to.equal(false);
+            expect(utils.isArray(undefined)).to.equal(false);
+            expect(utils.isArray('string')).to.equal(false);
+            expect(utils.isArray(true)).to.equal(false);
+        });
+    });
+    describe('isFunction', () => {
+        it('should return true when it\'s a function', () => {
+            expect(utils.isFunction(() => {})).to.equal(true);
+        });
+        it('should return false when it\'s not a function', () => {
+            expect(utils.isFunction(null)).to.equal(false);
+            expect(utils.isFunction(undefined)).to.equal(false);
+            expect(utils.isFunction('string')).to.equal(false);
+            expect(utils.isFunction(true)).to.equal(false);
+            expect(utils.isFunction([])).to.equal(false);
+        });
+    });
+    describe('isString', () => {
+        it('should return true when it\'s a string', () => {
+            expect(utils.isString('string')).to.equal(true);
+        });
+        it('should return false when it\'s not a string', () => {
+            expect(utils.isString(null)).to.equal(false);
+            expect(utils.isString(undefined)).to.equal(false);
+            expect(utils.isString(true)).to.equal(false);
+            expect(utils.isString([])).to.equal(false);
+            expect(utils.isString(() => {})).to.equal(false);
+        });
+    });
+    describe('shouldLogMetrics', () => {
+        it('should return true if route is not excluded', () => {
+            const excludeRoutes = ['route1', 'route2'];
+            const route = 'route';
+            expect(utils.shouldLogMetrics(excludeRoutes, route)).to.equal(true);
+        });
+        it('should return false if route is excluded', () => {
+            const excludeRoutes = ['route1', 'route2'];
+            const route = 'route1';
+            expect(utils.shouldLogMetrics(excludeRoutes, route)).to.equal(false);
+        });
+    });
+    describe('validateInput', () => {
+        it('should return input if valid', () => {
+            const value = utils.validateInput({
+                input: 'string',
+                isValidInputFn: utils.isString,
+                defaultValue: 'default-string'
+            });
+            expect(value).to.equal('string');
+        });
+        it('should return input value if empty string', () => {
+            const value = utils.validateInput({
+                input: '',
+                isValidInputFn: utils.isString,
+                defaultValue: 'default-string'
+            });
+            expect(value).to.equal('');
+        });
+        it('should return input value if zero', () => {
+            const value = utils.validateInput({
+                input: 0,
+                isValidInputFn: (input) => typeof input === 'number',
+                defaultValue: 100
+            });
+            expect(value).to.equal(0);
+        });
+        it('should return default value if input is undefined', () => {
+            const value = utils.validateInput({
+                isValidInputFn: utils.isString,
+                defaultValue: 'default-string'
+            });
+            expect(value).to.equal('default-string');
+        });
+    });
+});

--- a/test/unit-test/utils-test.js
+++ b/test/unit-test/utils-test.js
@@ -5,7 +5,7 @@ const utils = require('../../src/utils');
 
 describe('utils', () => {
     describe('getMetricNames', () => {
-        it('', () => {
+        it('should include project name', () => {
             const metricNames = ['metric1'];
             const useUniqueHistogramName = true;
             const metricsPrefix = true;

--- a/test/unit-test/utils-test.js
+++ b/test/unit-test/utils-test.js
@@ -92,5 +92,14 @@ describe('utils', () => {
             });
             expect(value).to.equal('default-string');
         });
+        it('should throw if input is not valid', () => {
+            const fn = utils.validateInput.bind(utils.validateInput, {
+                input: true,
+                isValidInputFn: utils.isString,
+                defaultValue: 'default-string',
+                errorMessage: 'error message'
+            });
+            expect(fn).to.throw('error message');
+        });
     });
 });


### PR DESCRIPTION
* Provides support for custom / extra labels for each of the `http_*` metrics.

### Example

```js
promApiMetrics({
    metricsAdditionalLabels: ['user_group', 'role'],
    getMetricsAdditionalLabelValues: (req: Request) => {
        const { userGroup, role } = req.context;
        return {
            ...(userGroup ? { user_group: userGroup } : {}),
            ...(role ? { role } : {})
        };
    }
})
```

**Result:**

```
http_request_duration_seconds_bucket{le="0.1",method="POST",route="/path",code="200",user_group="admin",role="superadmin"} 0
http_request_duration_seconds_bucket{le="0.5",method="POST",route="/path",code="200",user_group="admin",role="superadmin"} 0
http_request_duration_seconds_bucket{le="1",method="POST",route="/path",code="200",user_group="admin",role="superadmin"} 0
http_request_duration_seconds_bucket{le="5",method="POST",route="/path",code="200",user_group="admin",role="superadmin"} 2
http_request_duration_seconds_bucket{le="+Inf",method="POST",route="/path",code="200",user_group="admin",role="superadmin"} 2
http_request_duration_seconds_sum{method="POST",route="/path",code="200",user_group="admin",role="superadmin"} 4.657347321
http_request_duration_seconds_count{method="POST",route="/path",code="200",user_group="admin",role="superadmin"} 2

```