### PR TITLE
feat: Support to exclude default metrics and other options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Features
 
 - Add support for custom labels addition to metrics
+- Add `httpMetricsPrefix` option to optionally add a prefix to HTTP metrics.
+- Add `excludeDefaultMetricLabels` option to exclude all or certain metrics that are added by default.
+- Add `useCountersForRequestSizeMetric` option to expose two counters for Request Size (`_sum` and `_count`) instead of Histogram.
+- Add `useCountersForResponseSizeMetric` option to expose two counters for Response Size (`_sum` and `_count`) instead of Histogram.
 
 ### Improvements
 

--- a/src/express-middleware.js
+++ b/src/express-middleware.js
@@ -43,9 +43,19 @@ class ExpressMiddleware {
                 code: res.statusCode,
                 ...this.setupOptions.extractAdditionalLabelValuesFn(req, res)
             };
-            this.setupOptions.requestSizeHistogram.observe(labels, req.metrics.contentLength);
+            if (this.setupOptions.useCountersForRequestSizeMetric) {
+                this.setupOptions.requestSizeSum.inc(labels, req.metrics.contentLength);
+                this.setupOptions.requestSizeCount.inc(labels);
+            } else {
+                this.setupOptions.requestSizeHistogram.observe(labels, req.metrics.contentLength);
+            }
+            if (this.setupOptions.useCountersForResponseSizeMetric) {
+                this.setupOptions.responseSizeSum.inc(labels, responseLength);
+                this.setupOptions.responseSizeCount.inc(labels);
+            } else {
+                this.setupOptions.responseSizeHistogram.observe(labels, responseLength);
+            }
             req.metrics.timer(labels);
-            this.setupOptions.responseSizeHistogram.observe(labels, responseLength);
             debug(`metrics updated, request length: ${req.metrics.contentLength}, response length: ${responseLength}`);
         }
     }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,32 +1,38 @@
 import { Request, RequestHandler, Response } from 'express';
 import { Context, Middleware } from 'koa';
 
-export default function middleware(options?: ApiMetricsOpts) : RequestHandler;
-export function koaMiddleware(options?: ApiMetricsOpts) : Middleware;
-export function expressMiddleware(options?: ApiMetricsOpts) : RequestHandler;
+export default function middleware(options?: ApiMetricsOpts): RequestHandler;
+export function koaMiddleware(options?: ApiMetricsOpts): Middleware;
+export function expressMiddleware(options?: ApiMetricsOpts): RequestHandler;
 export class HttpMetricsCollector {
-  constructor(options?: CollectorOpts)
-  static init(options?: CollectorOpts): void
-  static collect(res: Response | any): void
+    constructor(options?: CollectorOpts);
+    static init(options?: CollectorOpts): void;
+    static collect(res: Response | any): void;
 }
 
 export interface ApiMetricsOpts {
-  metricsPath?: string;
-  defaultMetricsInterval?: number;
-  durationBuckets?: number[];
-  requestSizeBuckets?: number[];
-  responseSizeBuckets?: number[];
-  useUniqueHistogramName?: boolean;
-  metricsPrefix?: string;
-  excludeRoutes?:string[];
-  includeQueryParams?: boolean;
-  additionalLabels?: string[];
-  extractAdditionalLabelValuesFn?: ((req: Request, res: Response) => Record<string, unknown>) | ((ctx: Context) => Record<string, unknown>)
+    metricsPath?: string;
+    defaultMetricsInterval?: number;
+    durationBuckets?: number[];
+    requestSizeBuckets?: number[];
+    responseSizeBuckets?: number[];
+    useUniqueHistogramName?: boolean;
+    metricsPrefix?: string;
+    httpMetricsPrefix?: string;
+    excludeRoutes?: string[];
+    includeQueryParams?: boolean;
+    additionalLabels?: string[];
+    extractAdditionalLabelValuesFn?:
+        | ((req: Request, res: Response) => Record<string, unknown>)
+        | ((ctx: Context) => Record<string, unknown>);
+    excludeDefaultMetricLabels?: boolean | string[];
+    useCountersForResponseSizeMetric?: boolean;
+    useCountersForRequestSizeMetric?: boolean;
 }
 
 export interface CollectorOpts {
-  durationBuckets?: number[];
-  countClientErrors?: boolean;
-  useUniqueHistogramName?: boolean
-  prefix?: string;
+    durationBuckets?: number[];
+    countClientErrors?: boolean;
+    useUniqueHistogramName?: boolean;
+    prefix?: string;
 }

--- a/src/koa-middleware.js
+++ b/src/koa-middleware.js
@@ -45,9 +45,19 @@ class KoaMiddleware {
                 code: ctx.res.statusCode,
                 ...this.setupOptions.extractAdditionalLabelValuesFn(ctx)
             };
-            this.setupOptions.requestSizeHistogram.observe(labels, ctx.req.metrics.contentLength);
+            if (this.setupOptions.useCountersForRequestSizeMetric) {
+                this.setupOptions.requestSizeSum.inc(labels, ctx.req.metrics.contentLength);
+                this.setupOptions.requestSizeCount.inc(labels);
+            } else {
+                this.setupOptions.requestSizeHistogram.observe(labels, ctx.req.metrics.contentLength);
+            }
+            if (this.setupOptions.useCountersForResponseSizeMetric) {
+                this.setupOptions.responseSizeSum.inc(labels, responseLength);
+                this.setupOptions.responseSizeCount.inc(labels);
+            } else {
+                this.setupOptions.responseSizeHistogram.observe(labels, responseLength);
+            }
             ctx.req.metrics.timer(labels);
-            this.setupOptions.responseSizeHistogram.observe(labels, responseLength);
             debug(`metrics updated, request length: ${ctx.req.metrics.contentLength}, response length: ${responseLength}`);
         }
     }

--- a/src/metrics-middleware.js
+++ b/src/metrics-middleware.js
@@ -18,12 +18,28 @@ module.exports = (appVersion, projectName, framework = 'express') => {
             responseSizeBuckets,
             useUniqueHistogramName,
             metricsPrefix,
+            httpMetricsPrefix,
             excludeRoutes,
             includeQueryParams,
             additionalLabels = [],
-            extractAdditionalLabelValuesFn
+            extractAdditionalLabelValuesFn,
+            excludeDefaultMetricLabels,
+            useCountersForRequestSizeMetric,
+            useCountersForResponseSizeMetric
         } = options;
         debug(`Init metrics middleware with options: ${JSON.stringify(options)}`);
+
+        utils.validateInput({
+            input: metricsPrefix,
+            isValidInputFn: utils.isString,
+            errorMessage: 'metricsPrefix should be an string'
+        });
+
+        utils.validateInput({
+            input: httpMetricsPrefix,
+            isValidInputFn: utils.isString,
+            errorMessage: 'httpMetricsPrefix should be an string'
+        });
 
         setupOptions.metricsRoute = utils.validateInput({
             input: metricsPath,
@@ -40,6 +56,7 @@ module.exports = (appVersion, projectName, framework = 'express') => {
         });
 
         setupOptions.includeQueryParams = includeQueryParams;
+        
         setupOptions.defaultMetricsInterval = defaultMetricsInterval;
 
         setupOptions.additionalLabels = utils.validateInput({
@@ -56,28 +73,58 @@ module.exports = (appVersion, projectName, framework = 'express') => {
             errorMessage: 'extractAdditionalLabelValuesFn should be a function'
         });
 
-        const metricNames = utils.getMetricNames(
-            {
-                http_request_duration_seconds: 'http_request_duration_seconds',
+        setupOptions.excludeDefaultMetricLabels = utils.validateInput({
+            input: excludeDefaultMetricLabels,
+            isValidInputFn: (input) => utils.isArray(input) || utils.isBoolean(input),
+            defaultValue: [],
+            errorMessage: 'excludeDefaultMetricLabels should be an array or a boolean'
+        });
+
+        setupOptions.useCountersForRequestSizeMetric = utils.validateInput({
+            input: useCountersForRequestSizeMetric,
+            isValidInputFn: utils.isBoolean,
+            defaultValue: false,
+            errorMessage: 'useCountersForRequestSizeMetric should be a boolean'
+        });
+
+        setupOptions.useCountersForResponseSizeMetric = utils.validateInput({
+            input: useCountersForResponseSizeMetric,
+            isValidInputFn: utils.isBoolean,
+            defaultValue: false,
+            errorMessage: 'useCountersForResponseSizeMetric should be a boolean'
+        });
+
+        const metricNames = utils.getMetricNames({
+            metricNames: {
                 app_version: 'app_version',
+                http_request_duration_seconds: 'http_request_duration_seconds',
                 http_request_size_bytes: 'http_request_size_bytes',
+                http_request_size_bytes_sum: 'http_request_size_bytes_sum',
+                http_request_size_bytes_count: 'http_request_size_bytes_count',
                 http_response_size_bytes: 'http_response_size_bytes',
+                http_response_size_bytes_sum: 'http_response_size_bytes_sum',
+                http_response_size_bytes_count: 'http_response_size_bytes_count',
                 defaultMetricsPrefix: ''
             },
             useUniqueHistogramName,
             metricsPrefix,
+            httpMetricsPrefix,
             projectName
-        );
+        });
 
         Prometheus.collectDefaultMetrics({ timeout: defaultMetricsInterval, prefix: `${metricNames.defaultMetricsPrefix}` });
 
         PrometheusRegisterAppVersion(appVersion, metricNames.app_version);
 
+        const defaultMetricLabels = ['method', 'route', 'code'];
+
         const metricLabels = [
-            'method',
-            'route',
-            'code',
-            ...additionalLabels
+            ...additionalLabels,
+            ...excludeDefaultMetricLabels === true
+                ? []
+                : Array.isArray(excludeDefaultMetricLabels)
+                    ? defaultMetricLabels.filter((defaultLabel) => excludeDefaultMetricLabels.indexOf(defaultLabel) < 0)
+                    : defaultMetricLabels
         ].filter(Boolean);
 
         // Buckets for response time from 1ms to 500ms
@@ -85,25 +132,54 @@ module.exports = (appVersion, projectName, framework = 'express') => {
         // Buckets for request size from 5 bytes to 10000 bytes
         const defaultSizeBytesBuckets = [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000];
 
+        // Request Size Metric
+        if (useCountersForRequestSizeMetric) {
+            setupOptions.requestSizeSum = Prometheus.register.getSingleMetric(metricNames.http_request_size_bytes_sum) || new Prometheus.Counter({
+                name: metricNames.http_request_size_bytes_sum,
+                help: 'Sum of the size of HTTP requests in bytes',
+                labelNames: metricLabels
+            });
+            setupOptions.requestSizeCount = Prometheus.register.getSingleMetric(metricNames.http_request_size_bytes_count) || new Prometheus.Counter({
+                name: metricNames.http_request_size_bytes_count,
+                help: 'Count of the size of HTTP requests',
+                labelNames: metricLabels
+            });
+        } else {
+            setupOptions.requestSizeHistogram = Prometheus.register.getSingleMetric(metricNames.http_request_size_bytes) || new Prometheus.Histogram({
+                name: metricNames.http_request_size_bytes,
+                help: 'Size of HTTP requests in bytes',
+                labelNames: metricLabels,
+                buckets: requestSizeBuckets || defaultSizeBytesBuckets
+            });
+        }
+
+        // Response Size Metric
+        if (useCountersForResponseSizeMetric) {
+            setupOptions.responseSizeSum = Prometheus.register.getSingleMetric(metricNames.http_response_size_bytes_sum) || new Prometheus.Counter({
+                name: metricNames.http_response_size_bytes_sum,
+                help: 'Sum of the size of HTTP responses in bytes',
+                labelNames: metricLabels
+            });
+            setupOptions.responseSizeCount = Prometheus.register.getSingleMetric(metricNames.http_response_size_bytes_count) || new Prometheus.Counter({
+                name: metricNames.http_response_size_bytes_count,
+                help: 'Count of the size of HTTP responses',
+                labelNames: metricLabels
+            });
+        } else {
+            setupOptions.responseSizeHistogram = Prometheus.register.getSingleMetric(metricNames.http_response_size_bytes) || new Prometheus.Histogram({
+                name: metricNames.http_response_size_bytes,
+                help: 'Size of HTTP response in bytes',
+                labelNames: metricLabels,
+                buckets: responseSizeBuckets || defaultSizeBytesBuckets
+            });
+        }
+
+        // Response Time Metric
         setupOptions.responseTimeHistogram = Prometheus.register.getSingleMetric(metricNames.http_request_duration_seconds) || new Prometheus.Histogram({
             name: metricNames.http_request_duration_seconds,
             help: 'Duration of HTTP requests in seconds',
             labelNames: metricLabels,
             buckets: durationBuckets || defaultDurationSecondsBuckets
-        });
-
-        setupOptions.requestSizeHistogram = Prometheus.register.getSingleMetric(metricNames.http_request_size_bytes) || new Prometheus.Histogram({
-            name: metricNames.http_request_size_bytes,
-            help: 'Size of HTTP requests in bytes',
-            labelNames: metricLabels,
-            buckets: requestSizeBuckets || defaultSizeBytesBuckets
-        });
-
-        setupOptions.responseSizeHistogram = Prometheus.register.getSingleMetric(metricNames.http_response_size_bytes) || new Prometheus.Histogram({
-            name: metricNames.http_response_size_bytes,
-            help: 'Size of HTTP response in bytes',
-            labelNames: metricLabels,
-            buckets: responseSizeBuckets || defaultSizeBytesBuckets
         });
 
         return frameworkMiddleware(framework);

--- a/src/request-response-collector.js
+++ b/src/request-response-collector.js
@@ -96,7 +96,7 @@ function _init(options = {}) {
     };
 
     const { durationBuckets, countClientErrors, useUniqueHistogramName, prefix } = options;
-    metricNames = utils.getMetricNames(metricNames, useUniqueHistogramName, prefix, projectName);
+    metricNames = utils.getMetricNames({ metricNames, useUniqueHistogramName, metricsPrefix: prefix, projectName });
 
     southboundResponseTimeHistogram = Prometheus.register.getSingleMetric(metricNames.southbound_request_duration_seconds) ||
         new Prometheus.Histogram({

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,18 +1,22 @@
 'use strict';
 
-const getMetricNames = (metricNames, useUniqueHistogramName, metricsPrefix, projectName) => {
+const getMetricNames = ({ metricNames, useUniqueHistogramName, metricsPrefix, httpMetricsPrefix, projectName }) => {
     const prefix = useUniqueHistogramName === true ? projectName : metricsPrefix;
 
-    if (prefix) {
-        Object.keys(metricNames).forEach(key => {
+    Object.keys(metricNames).forEach(key => {
+        if (httpMetricsPrefix && key.startsWith('http_')) {
+            metricNames[key] = `${httpMetricsPrefix}_${metricNames[key]}`;
+        } else if (prefix) {
             metricNames[key] = `${prefix}_${metricNames[key]}`;
-        });
-    }
+        }
+    });
 
     return metricNames;
 };
 
 const isArray = (input) => Array.isArray(input);
+
+const isBoolean = (input) => typeof input === 'boolean';
 
 const isFunction = (input) => typeof input === 'function';
 
@@ -34,6 +38,7 @@ const validateInput = ({ input, isValidInputFn, defaultValue, errorMessage }) =>
 
 module.exports.getMetricNames = getMetricNames;
 module.exports.isArray = isArray;
+module.exports.isBoolean = isBoolean;
 module.exports.isFunction = isFunction;
 module.exports.isString = isString;
 module.exports.shouldLogMetrics = shouldLogMetrics;

--- a/test/unit-test/metric-middleware-koa-test.js
+++ b/test/unit-test/metric-middleware-koa-test.js
@@ -788,5 +788,77 @@ describe('metrics-middleware', () => {
                 Prometheus.register.clear();
             });
         });
+        describe('when calling the function with excludeDefaultMetricLabels option', () => {
+            it('or it\'s undefined', () => {
+                middleware();
+                expect(Prometheus.register.getSingleMetric('http_request_size_bytes').labelNames).to.have.members(['method', 'route', 'code']);
+            });
+            it('and it\'s false', () => {
+                middleware({
+                    excludeDefaultMetricLabels: false
+                });
+                expect(Prometheus.register.getSingleMetric('http_request_size_bytes').labelNames).to.have.members(['method', 'route', 'code']);
+            });
+            it('and it\'s true', () => {
+                middleware({
+                    excludeDefaultMetricLabels: true
+                });
+                expect(Prometheus.register.getSingleMetric('http_request_size_bytes').labelNames).to.have.members([]);
+            });
+            it('and it\'s an array', () => {
+                middleware({
+                    excludeDefaultMetricLabels: ['route', 'code']
+                });
+                expect(Prometheus.register.getSingleMetric('http_request_size_bytes').labelNames).to.have.members(['method']);
+            });
+            it('and it\'s other type', () => {
+                expect(() => {
+                    middleware({
+                        excludeDefaultMetricLabels: 'invalid',
+                    });
+                }).to.throw('excludeDefaultMetricLabels should be an array or a boolean');
+            });
+            afterEach(() => {
+                Prometheus.register.clear();
+            });
+        });
+        describe('when calling the function with useCountersForRequestSizeMetric option', () => {
+            before(() => {
+                middleware({
+                    useCountersForRequestSizeMetric: true
+                });
+            });
+            it('shouldn\'t have http_request_size_bytes metric', () => {
+                expect(Prometheus.register.getSingleMetric('http_request_size_bytes')).to.equal(undefined);
+            });
+            it('should have http_request_size_bytes_sum with the right labels', () => {
+                expect(Prometheus.register.getSingleMetric('http_request_size_bytes_sum').labelNames).to.have.members(['method', 'route', 'code']);
+            });
+            it('should have http_request_size_bytes_count with the right labels', () => {
+                expect(Prometheus.register.getSingleMetric('http_request_size_bytes_count').labelNames).to.have.members(['method', 'route', 'code']);
+            });
+            after(() => {
+                Prometheus.register.clear();
+            });
+        });
+        describe('when calling the function with useCountersForResponseSizeMetric option', () => {
+            before(() => {
+                middleware({
+                    useCountersForResponseSizeMetric: true
+                });
+            });
+            it('shouldn\'t have http_response_size_bytes metric', () => {
+                expect(Prometheus.register.getSingleMetric('http_response_size_bytes')).to.equal(undefined);
+            });
+            it('should have http_response_size_bytes_sum with the right labels', () => {
+                expect(Prometheus.register.getSingleMetric('http_response_size_bytes_sum').labelNames).to.have.members(['method', 'route', 'code']);
+            });
+            it('should have http_response_size_bytes_count with the right labels', () => {
+                expect(Prometheus.register.getSingleMetric('http_response_size_bytes_count').labelNames).to.have.members(['method', 'route', 'code']);
+            });
+            after(() => {
+                Prometheus.register.clear();
+            });
+        });
     });
 });

--- a/test/unit-test/metric-middleware-test.js
+++ b/test/unit-test/metric-middleware-test.js
@@ -654,4 +654,76 @@ describe('metrics-middleware', () => {
             Prometheus.register.clear();
         });
     });
+    describe('when calling the function with excludeDefaultMetricLabels option', () => {
+        it('or it\'s undefined', () => {
+            middleware();
+            expect(Prometheus.register.getSingleMetric('http_request_size_bytes').labelNames).to.have.members(['method', 'route', 'code']);
+        });
+        it('and it\'s false', () => {
+            middleware({
+                excludeDefaultMetricLabels: false
+            });
+            expect(Prometheus.register.getSingleMetric('http_request_size_bytes').labelNames).to.have.members(['method', 'route', 'code']);
+        });
+        it('and it\'s true', () => {
+            middleware({
+                excludeDefaultMetricLabels: true
+            });
+            expect(Prometheus.register.getSingleMetric('http_request_size_bytes').labelNames).to.have.members([]);
+        });
+        it('and it\'s an array', () => {
+            middleware({
+                excludeDefaultMetricLabels: ['route', 'code']
+            });
+            expect(Prometheus.register.getSingleMetric('http_request_size_bytes').labelNames).to.have.members(['method']);
+        });
+        it('and it\'s other type', () => {
+            expect(() => {
+                middleware({
+                    excludeDefaultMetricLabels: 'invalid',
+                });
+            }).to.throw('excludeDefaultMetricLabels should be an array or a boolean');
+        });
+        afterEach(() => {
+            Prometheus.register.clear();
+        });
+    });
+    describe('when calling the function with useCountersForRequestSizeMetric option', () => {
+        before(() => {
+            middleware({
+                useCountersForRequestSizeMetric: true
+            });
+        });
+        it('shouldn\'t have http_request_size_bytes metric', () => {
+            expect(Prometheus.register.getSingleMetric('http_request_size_bytes')).to.equal(undefined);
+        });
+        it('should have http_request_size_bytes_sum with the right labels', () => {
+            expect(Prometheus.register.getSingleMetric('http_request_size_bytes_sum').labelNames).to.have.members(['method', 'route', 'code']);
+        });
+        it('should have http_request_size_bytes_count with the right labels', () => {
+            expect(Prometheus.register.getSingleMetric('http_request_size_bytes_count').labelNames).to.have.members(['method', 'route', 'code']);
+        });
+        after(() => {
+            Prometheus.register.clear();
+        });
+    });
+    describe('when calling the function with useCountersForResponseSizeMetric option', () => {
+        before(() => {
+            middleware({
+                useCountersForResponseSizeMetric: true
+            });
+        });
+        it('shouldn\'t have http_response_size_bytes metric', () => {
+            expect(Prometheus.register.getSingleMetric('http_response_size_bytes')).to.equal(undefined);
+        });
+        it('should have http_response_size_bytes_sum with the right labels', () => {
+            expect(Prometheus.register.getSingleMetric('http_response_size_bytes_sum').labelNames).to.have.members(['method', 'route', 'code']);
+        });
+        it('should have http_response_size_bytes_count with the right labels', () => {
+            expect(Prometheus.register.getSingleMetric('http_response_size_bytes_count').labelNames).to.have.members(['method', 'route', 'code']);
+        });
+        after(() => {
+            Prometheus.register.clear();
+        });
+    });
 });

--- a/test/unit-test/utils-test.js
+++ b/test/unit-test/utils-test.js
@@ -6,11 +6,21 @@ const utils = require('../../src/utils');
 describe('utils', () => {
     describe('getMetricNames', () => {
         it('should include project name', () => {
-            const metricNames = ['metric1'];
+            const metricNames = { metric: 'metric', http_metric: 'http_metric' };
             const useUniqueHistogramName = true;
-            const metricsPrefix = true;
+            const metricsPrefix = 'prefix';
             const projectName = 'mock_project';
-            expect(utils.getMetricNames(metricNames, useUniqueHistogramName, metricsPrefix, projectName)[0]).to.equal('mock_project_metric1');
+            const newMetricNames = utils.getMetricNames({ metricNames, useUniqueHistogramName, metricsPrefix, projectName });
+            expect(Object.values(newMetricNames)).to.have.members(['mock_project_metric', 'mock_project_http_metric']);
+        });
+        it('should include prefix and http prefix', () => {
+            const metricNames = { metric: 'metric', http_metric: 'http_metric' };
+            const useUniqueHistogramName = false;
+            const metricsPrefix = 'prefix';
+            const projectName = 'mock_project';
+            const httpMetricsPrefix = 'http_prefix';
+            const newMetricNames = utils.getMetricNames({ metricNames, useUniqueHistogramName, metricsPrefix, httpMetricsPrefix, projectName });
+            expect(Object.values(newMetricNames)).to.have.members(['prefix_metric', 'http_prefix_http_metric']);
         });
     });
     describe('isArray', () => {


### PR DESCRIPTION
* Adds `httpMetricsPrefix` option to optionally add a prefix to HTTP metrics.
* Adds `excludeDefaultMetricLabels` option to exclude all or certain metrics that are added by default.
* Adds `useCountersForRequestSizeMetric` option to expose two counters for Request Size (`_sum` and `_count`) instead of Histogram.
* Adds `useCountersForResponseSizeMetric` option to expose two counters for Response Size (`_sum` and `_count`) instead of Histogram.