### PR TITLE
Check if properRoute is found before acting on it

### DIFF
--- a/src/koa-middleware.js
+++ b/src/koa-middleware.js
@@ -33,7 +33,7 @@ class KoaMiddleware {
         }
     }
 
-    _handleResponse (ctx) {
+    _handleResponse(ctx) {
         const responseLength = parseInt(ctx.response.get('Content-Length')) || 0;
 
         const route = this._getRoute(ctx) || 'N/A';
@@ -92,6 +92,12 @@ class KoaMiddleware {
                 return route;
             }
         });
+
+        // If proper route is not found, send an undefined route
+        // The caller is responsible for setting a default "N/A" route in this case
+        if (!properRoute) {
+            return undefined;
+        }
 
         let route = properRoute.path;
         route = route.endsWith('/') ? route.substring(0, route.length - 1) : route;

--- a/test/integration-tests/koa/middleware-test.js
+++ b/test/integration-tests/koa/middleware-test.js
@@ -679,6 +679,23 @@ describe('when using koa framework', () => {
                     });
             });
         });
+        describe('when calling wildcard endpoint', function () {
+            before(() => {
+                const wildcardPath = '/wild-path/' + Math.floor(Math.random() * 10);
+                return supertest(app)
+                    .get(wildcardPath)
+                    .expect(200)
+                    .then((res) => {});
+            });
+            it('should add it to the histogram', () => {
+                return supertest(app)
+                    .get('/metrics')
+                    .expect(200)
+                    .then((res) => {
+                        expect(res.text).to.contain('method="GET",route="N/A",code="200"');
+                    });
+            });
+        });
         it('should get metrics as json', () => {
             return supertest(app)
                 .get('/metrics.json')

--- a/test/integration-tests/koa/server/koa-server.js
+++ b/test/integration-tests/koa/server/koa-server.js
@@ -78,4 +78,10 @@ router.post('/test', async (ctx, next) => {
     return next();
 });
 
+router.get('/wild-path/(.*)', (ctx, next) => {
+    ctx.status = 200;
+    ctx.body = { message: 'Wildcard route reached!' };
+    return next();
+});
+
 module.exports = app;


### PR DESCRIPTION
In the cases where the request route is not matched to any Koa route,
bail out before trying to format the path string.

Issue: #59