### PR TITLE
add a fix to the case: when req.originalUrl suffix is / (for example:…

### DIFF
--- a/src/express-middleware.js
+++ b/src/express-middleware.js
@@ -57,11 +57,16 @@ class ExpressMiddleware {
                 route = route ? route + req.route.path : req.route.path;
             }
 
+            let originalUrl = req.originalUrl;
+            if (originalUrl.substr(originalUrl.length - 1) === '/'){
+                originalUrl = originalUrl.substr(0, originalUrl.length - 1);
+            }
+
             if (!route || route === '' || typeof route !== 'string') {
-                route = req.originalUrl.split('?')[0];
+                route = originalUrl.split('?')[0];
             } else {
                 const splittedRoute = route.split('/');
-                const splittedUrl = req.originalUrl.split('?')[0].split('/');
+                const splittedUrl = originalUrl.split('?')[0].split('/');
                 const routeIndex = splittedUrl.length - splittedRoute.length + 1;
 
                 const baseUrl = splittedUrl.slice(0, routeIndex).join('/');

--- a/test/integration-tests/express/middleware-test.js
+++ b/test/integration-tests/express/middleware-test.js
@@ -700,5 +700,39 @@ describe('when using express framework', () => {
                     JSON.parse(res.text);
                 });
         });
+        describe('when calling a GET endpoint with suffix /', () => {
+            before(() => {
+                return supertest(app)
+                    .get('/hello/')
+                    .expect(200)
+                    .then((res) => {});
+            });
+            it('should add it to the histogram', () => {
+                return supertest(app)
+                    .get('/metrics')
+                    .expect(200)
+                    .then((res) => {
+                        expect(res.text).to.contain('method="GET",route="/hello",code="200"');
+                    });
+            });
+        });
+        describe('when calling a POST endpoint with suffix /', () => {
+            before(() => {
+                return supertest(app)
+                    .post('/test/')
+                    .send({ name: 'john' })
+                    .set('Accept', 'application/json')
+                    .expect(201)
+                    .then((res) => {});
+            });
+            it('should add it to the histogram', () => {
+                return supertest(app)
+                    .get('/metrics')
+                    .expect(200)
+                    .then((res) => {
+                        expect(res.text).to.contain('method="POST",route="/test",code="201"');
+                    });
+            });
+        });
     });
 });


### PR DESCRIPTION
… '/hello/') it causes to metrics route be double value of req.route.path (as /hello/hello/), add a fix in _getRoute method