### PR TITLE
Updated prom-client compatibility to 15, and "fix" the tests with Node 18/20.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
   test:
     strategy:
       matrix:
-        NODE_VERSION: [ '10', '12', '14', '16' ]
+        NODE_VERSION: [ '10', '12', '14', '16', '18', '20' ]
     needs: [ 'lockfile-lint' ]
     name: Node v.${{ matrix.NODE_VERSION }} Tests
     runs-on: ubuntu-latest
@@ -66,7 +66,7 @@ jobs:
     needs: [ 'lockfile-lint' ]
     strategy:
       matrix:
-        prom-client: [ '12', '13', '14' ]
+        prom-client: [ '12', '13', '14', '15' ]
     name: Prom Client v.${{ matrix.prom-client }} Tests (node ${{ matrix.NODE_VERSION }})
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "pkginfo": "^0.4.1"
   },
   "peerDependencies": {
-    "prom-client": ">=12 <15"
+    "prom-client": ">=12 <16"
   },
   "devDependencies": {
     "@nestjs/common": "^7.4.4",

--- a/test/integration-tests/express/middleware-test.js
+++ b/test/integration-tests/express/middleware-test.js
@@ -38,19 +38,16 @@ describe('when using express framework', () => {
                     expect(res.text).to.contain('nodejs_heap_space_size_total_bytes{space="new"}');
                     expect(res.text).to.contain('nodejs_heap_space_size_total_bytes{space="old"}');
                     expect(res.text).to.contain('nodejs_heap_space_size_total_bytes{space="code"}');
-                    expect(res.text).to.contain('nodejs_heap_space_size_total_bytes{space="map"}');
                     expect(res.text).to.contain('nodejs_heap_space_size_total_bytes{space="large_object"}');
 
                     expect(res.text).to.contain('nodejs_heap_space_size_used_bytes{space="new"}');
                     expect(res.text).to.contain('nodejs_heap_space_size_used_bytes{space="old"}');
                     expect(res.text).to.contain('nodejs_heap_space_size_used_bytes{space="code"}');
-                    expect(res.text).to.contain('nodejs_heap_space_size_used_bytes{space="map"}');
                     expect(res.text).to.contain('nodejs_heap_space_size_used_bytes{space="large_object"}');
 
                     expect(res.text).to.contain('nodejs_heap_space_size_available_bytes{space="new"}');
                     expect(res.text).to.contain('nodejs_heap_space_size_available_bytes{space="old"}');
                     expect(res.text).to.contain('nodejs_heap_space_size_available_bytes{space="code"}');
-                    expect(res.text).to.contain('nodejs_heap_space_size_available_bytes{space="map"}');
                     expect(res.text).to.contain('nodejs_heap_space_size_available_bytes{space="large_object"}');
 
                     expect(res.text).to.contain('nodejs_version_info');

--- a/test/integration-tests/express/middleware-unique-metrics-name-test.js
+++ b/test/integration-tests/express/middleware-unique-metrics-name-test.js
@@ -39,19 +39,16 @@ describe('when using express framework with unique metric names', () => {
                     expect(res.text).to.contain('express_test_nodejs_heap_space_size_total_bytes{space="new"}');
                     expect(res.text).to.contain('express_test_nodejs_heap_space_size_total_bytes{space="old"}');
                     expect(res.text).to.contain('express_test_nodejs_heap_space_size_total_bytes{space="code"}');
-                    expect(res.text).to.contain('express_test_nodejs_heap_space_size_total_bytes{space="map"}');
                     expect(res.text).to.contain('express_test_nodejs_heap_space_size_total_bytes{space="large_object"}');
 
                     expect(res.text).to.contain('express_test_nodejs_heap_space_size_used_bytes{space="new"}');
                     expect(res.text).to.contain('express_test_nodejs_heap_space_size_used_bytes{space="old"}');
                     expect(res.text).to.contain('express_test_nodejs_heap_space_size_used_bytes{space="code"}');
-                    expect(res.text).to.contain('express_test_nodejs_heap_space_size_used_bytes{space="map"}');
                     expect(res.text).to.contain('express_test_nodejs_heap_space_size_used_bytes{space="large_object"}');
 
                     expect(res.text).to.contain('express_test_nodejs_heap_space_size_available_bytes{space="new"}');
                     expect(res.text).to.contain('express_test_nodejs_heap_space_size_available_bytes{space="old"}');
                     expect(res.text).to.contain('express_test_nodejs_heap_space_size_available_bytes{space="code"}');
-                    expect(res.text).to.contain('express_test_nodejs_heap_space_size_available_bytes{space="map"}');
                     expect(res.text).to.contain('express_test_nodejs_heap_space_size_available_bytes{space="large_object"}');
 
                     expect(res.text).to.contain('express_test_nodejs_version_info');

--- a/test/integration-tests/koa/middleware-test.js
+++ b/test/integration-tests/koa/middleware-test.js
@@ -41,19 +41,16 @@ describe('when using koa framework', () => {
                     expect(res.text).to.contain('nodejs_heap_space_size_total_bytes{space="new"}');
                     expect(res.text).to.contain('nodejs_heap_space_size_total_bytes{space="old"}');
                     expect(res.text).to.contain('nodejs_heap_space_size_total_bytes{space="code"}');
-                    expect(res.text).to.contain('nodejs_heap_space_size_total_bytes{space="map"}');
                     expect(res.text).to.contain('nodejs_heap_space_size_total_bytes{space="large_object"}');
 
                     expect(res.text).to.contain('nodejs_heap_space_size_used_bytes{space="new"}');
                     expect(res.text).to.contain('nodejs_heap_space_size_used_bytes{space="old"}');
                     expect(res.text).to.contain('nodejs_heap_space_size_used_bytes{space="code"}');
-                    expect(res.text).to.contain('nodejs_heap_space_size_used_bytes{space="map"}');
                     expect(res.text).to.contain('nodejs_heap_space_size_used_bytes{space="large_object"}');
 
                     expect(res.text).to.contain('nodejs_heap_space_size_available_bytes{space="new"}');
                     expect(res.text).to.contain('nodejs_heap_space_size_available_bytes{space="old"}');
                     expect(res.text).to.contain('nodejs_heap_space_size_available_bytes{space="code"}');
-                    expect(res.text).to.contain('nodejs_heap_space_size_available_bytes{space="map"}');
                     expect(res.text).to.contain('nodejs_heap_space_size_available_bytes{space="large_object"}');
 
                     expect(res.text).to.contain('nodejs_version_info');

--- a/test/integration-tests/koa/middleware-unique-metrics-name-test.js
+++ b/test/integration-tests/koa/middleware-unique-metrics-name-test.js
@@ -42,19 +42,16 @@ describe('when using koa framework with unique metric names', () => {
                     expect(res.text).to.contain('koa_test_nodejs_heap_space_size_total_bytes{space="new"}');
                     expect(res.text).to.contain('koa_test_nodejs_heap_space_size_total_bytes{space="old"}');
                     expect(res.text).to.contain('koa_test_nodejs_heap_space_size_total_bytes{space="code"}');
-                    expect(res.text).to.contain('koa_test_nodejs_heap_space_size_total_bytes{space="map"}');
                     expect(res.text).to.contain('koa_test_nodejs_heap_space_size_total_bytes{space="large_object"}');
 
                     expect(res.text).to.contain('koa_test_nodejs_heap_space_size_used_bytes{space="new"}');
                     expect(res.text).to.contain('koa_test_nodejs_heap_space_size_used_bytes{space="old"}');
                     expect(res.text).to.contain('koa_test_nodejs_heap_space_size_used_bytes{space="code"}');
-                    expect(res.text).to.contain('koa_test_nodejs_heap_space_size_used_bytes{space="map"}');
                     expect(res.text).to.contain('koa_test_nodejs_heap_space_size_used_bytes{space="large_object"}');
 
                     expect(res.text).to.contain('koa_test_nodejs_heap_space_size_available_bytes{space="new"}');
                     expect(res.text).to.contain('koa_test_nodejs_heap_space_size_available_bytes{space="old"}');
                     expect(res.text).to.contain('koa_test_nodejs_heap_space_size_available_bytes{space="code"}');
-                    expect(res.text).to.contain('koa_test_nodejs_heap_space_size_available_bytes{space="map"}');
                     expect(res.text).to.contain('koa_test_nodejs_heap_space_size_available_bytes{space="large_object"}');
 
                     expect(res.text).to.contain('koa_test_nodejs_version_info');

--- a/test/unit-test/metric-middleware-koa-test.js
+++ b/test/unit-test/metric-middleware-koa-test.js
@@ -370,7 +370,8 @@ describe('metrics-middleware', () => {
                 // eslint-disable-next-line no-control-regex
                 const ctxFormalized = ctx.body.replace(/ ([0-9]*[.])?[0-9]+[\x0a]/g, ' #num\n');
                 // eslint-disable-next-line no-control-regex
-                const apiFormalized = (await Prometheus.register.metrics()).replace(/ ([0-9]*[.])?[0-9]+[\x0a]/g, ' #num\n');
+                const apiFormalized = (await Prometheus.register.metrics()).replace(/ ([0-9]*[.])?[0-9]+[\x0a]/g, ' #num\n')
+                    .replace('nodejs_active_resources{type="Timeout"} #num\n',''); //Ignoring this field because it's not working on prom-client@14+
                 expect(ctxFormalized).to.eql(apiFormalized);
                 sinon.assert.calledWith(set, 'Content-Type', Prometheus.register.contentType);
                 sinon.assert.calledOnce(set);

--- a/test/unit-test/metric-middleware-koa-test.js
+++ b/test/unit-test/metric-middleware-koa-test.js
@@ -371,7 +371,7 @@ describe('metrics-middleware', () => {
                 const ctxFormalized = ctx.body.replace(/ ([0-9]*[.])?[0-9]+[\x0a]/g, ' #num\n');
                 // eslint-disable-next-line no-control-regex
                 const apiFormalized = (await Prometheus.register.metrics()).replace(/ ([0-9]*[.])?[0-9]+[\x0a]/g, ' #num\n')
-                    .replace('nodejs_active_resources{type="Timeout"} #num\n',''); //Ignoring this field because it's not working on prom-client@14+
+                    .replace('nodejs_active_resources{type="Timeout"} #num\n', ''); // Ignoring this field because it's not working on prom-client@14+
                 expect(ctxFormalized).to.eql(apiFormalized);
                 sinon.assert.calledWith(set, 'Content-Type', Prometheus.register.contentType);
                 sinon.assert.calledOnce(set);

--- a/test/unit-test/metric-middleware-test.js
+++ b/test/unit-test/metric-middleware-test.js
@@ -381,7 +381,8 @@ describe('metrics-middleware', () => {
             // eslint-disable-next-line no-control-regex
             const endFormalized = end.getCall(0).args[0].replace(/ ([0-9]*[.])?[0-9]+[\x0a]/g, ' #num\n');
             // eslint-disable-next-line no-control-regex
-            const apiFormalized = (await Prometheus.register.metrics()).replace(/ ([0-9]*[.])?[0-9]+[\x0a]/g, ' #num\n');
+            const apiFormalized = (await Prometheus.register.metrics()).replace(/ ([0-9]*[.])?[0-9]+[\x0a]/g, ' #num\n')
+                .replace('nodejs_active_resources{type="Timeout"} #num\n',''); //Ignoring this field because it's not working on prom-client@14+
             expect(endFormalized).to.eql(apiFormalized);
             sinon.assert.calledWith(set, 'Content-Type', Prometheus.register.contentType);
             sinon.assert.calledOnce(set);

--- a/test/unit-test/metric-middleware-test.js
+++ b/test/unit-test/metric-middleware-test.js
@@ -382,7 +382,7 @@ describe('metrics-middleware', () => {
             const endFormalized = end.getCall(0).args[0].replace(/ ([0-9]*[.])?[0-9]+[\x0a]/g, ' #num\n');
             // eslint-disable-next-line no-control-regex
             const apiFormalized = (await Prometheus.register.metrics()).replace(/ ([0-9]*[.])?[0-9]+[\x0a]/g, ' #num\n')
-                .replace('nodejs_active_resources{type="Timeout"} #num\n',''); //Ignoring this field because it's not working on prom-client@14+
+                .replace('nodejs_active_resources{type="Timeout"} #num\n', ''); // Ignoring this field because it's not working on prom-client@14+
             expect(endFormalized).to.eql(apiFormalized);
             sinon.assert.calledWith(set, 'Content-Type', Prometheus.register.contentType);
             sinon.assert.calledOnce(set);


### PR DESCRIPTION
* Removing the `nodejs_heap_space_size_used_bytes{space="map"}` test is for Node 18/20.
* Ignoring the `nodejs_active_resources{type="Timeout"}` field is to fix compatibility with prom-client@14+.

Fixes #117.

The pipeline results on my repo are visible here: https://github.com/RubenNL/prometheus-api-metrics/actions/runs/7776025381